### PR TITLE
Add TMDB Agent

### DIFF
--- a/mcp-agents/TMDB-Agent/Agent-Profile.md
+++ b/mcp-agents/TMDB-Agent/Agent-Profile.md
@@ -1,0 +1,140 @@
+![tag:TMDB-MCP](https://img.shields.io/badge/Innovation-Lab-blue)
+![tag:Movie-Recommendations](https://img.shields.io/badge/Movies-Recommendations-orange)
+![tag:TV-Shows](https://img.shields.io/badge/TV-Shows-green)
+![tag:Streaming-Availability](https://img.shields.io/badge/Streaming-Availability-yellow)
+
+# TMDB Agent
+
+## Description:
+
+The **TMDB Agent** is a conversational movie and TV show recommendation agent that translates natural-language mood descriptions into real, streaming-ready picks. It integrates with the **TMDB API** via a custom MCP server to deliver **mood-matched recommendations with live streaming availability** for your country — eliminating endless scrolling and decision fatigue.
+
+---
+
+## 🚀 Key Features
+
+### 🎭 Mood-Based Discovery
+- Understands natural-language vibes: *"dark and slow-burn"*, *"feel-good comedy"*, *"something mind-bending"*
+- Maps moods to **TMDB genre combinations and sort strategies**
+- Supports aliases: *tense*, *gripping*, *chill*, *trippy*, *sad*, *emotional*
+
+### 📺 Movies + TV Shows
+- Full support for both **movies and TV series**
+- Handles mixed-mood requests: *"I want dark, they want romantic"*
+- Runtime filtering: *"under 90 minutes"*, *"short films only"*
+
+### 🌍 Real-Time Streaming Availability
+- Checks **live watch providers** via TMDB (subscription, rent, buy)
+- Supports any country via ISO code (US, GB, IN, AU, CA…)
+- Concurrent provider lookups for all candidates simultaneously
+
+### 💾 Session Memory
+- Tracks rejections, seen titles, and a personal watchlist across turns
+- Skips already-seen titles in all future recommendations
+- Save picks: *"save The Dark Knight"* — retrieve later: *"show my watchlist"*
+
+---
+
+## 🧰 Available Tools
+
+### `resolve_mood` / `resolve_mood_tv`
+- **Purpose**: Discover movies or TV shows matching a vibe/mood
+- **Vibes**: on-edge, slow-burn, dark, intense, feel-good, romantic, cosy, mind-bending, scary, funny, action-packed, tearjerker
+
+### `search_movies` / `search_tv`
+- **Purpose**: Search TMDB by title to resolve IDs before similarity lookups
+
+### `get_similar` / `get_similar_tv`
+- **Purpose**: Find titles similar to a given TMDB ID
+
+### `get_recommendations`
+- **Purpose**: TMDB behavioural recommendations for a movie
+
+### `get_trending`
+- **Purpose**: Trending movies or TV shows (day or week)
+
+### `search_by_keyword`
+- **Purpose**: Find movies tagged with a specific keyword (heist, revenge, psychological…)
+
+### `get_movie_details` / `get_tv_details`
+- **Purpose**: Full details — runtime, genres, seasons, tagline
+
+### `check_watch_providers` / `check_tv_watch_providers`
+- **Purpose**: Live streaming availability for a list of IDs in a given country
+
+---
+
+## 🛠️ Capabilities
+
+### 🎬 Movie & TV Discovery
+- Mood-matched discovery across 12 curated vibes
+- Trending lookups for freshness signals
+- Keyword-tagged search for precision
+- Similarity chains from a favourite title
+
+### 📋 Smart Session Management
+- Rejection tracking — *"not that one"* removes a title from all future picks
+- Seen-title exclusion — *"mark Parasite as seen"*
+- Persistent watchlist across the session
+- Mixed-mood blending for groups with different tastes
+
+### 💬 Conversational Flow
+- One optional follow-up if vibe and context are unclear
+- Deterministic formatting — picks always display in the same clean structure
+- Feature hints surfaced after each recommendation set
+
+---
+
+## 💬 Example Queries
+
+### 🎭 Mood-Based
+- *"I want something dark and slow-burn tonight"*
+- *"Something mind-bending — I loved Inception"*
+- *"Cosy and feel-good, watching with family"*
+- *"Intense thriller, solo watch, under 2 hours"*
+
+### 📺 TV Mode
+- *"Something to binge — dark crime drama"*
+- *"Find shows similar to Succession"*
+- *"Cosy TV show for the weekend"*
+
+### 🔄 Follow-up Refinement
+- *"Not that one — already seen it"*
+- *"What's available on Netflix in the UK?"*
+- *"Save The Dark Knight to my watchlist"*
+- *"Show my watchlist"*
+
+### 🌍 Trending
+- *"What's trending in movies this week?"*
+- *"Most popular shows right now"*
+
+---
+
+## 🧪 Usage Examples
+
+### ✅ Mood + Context
+**Input**: `"I want something on-edge, watching solo, loved Parasite"`
+**Output**: 3–4 picks matching the thriller/crime vibe, similar to Parasite's class tension, with streaming service listed for each.
+
+### ✅ Mixed Moods
+**Input**: `"I want dark, they want romantic — we can't decide"`
+**Output**: Picks that blend both moods — dark romance or emotionally charged drama — available to stream.
+
+### ✅ Runtime Filter
+**Input**: `"Feel-good comedy under 90 minutes"`
+**Output**: Comedy picks filtered to under 90 minutes, streaming-ready.
+
+---
+
+## ⚙️ Technical Benefits
+
+### ✅ No Scroll Fatigue
+- One message in, curated picks out — no genre browsing required
+
+### ✅ Live Availability
+- Streaming data is fetched live from TMDB, not cached or stale
+
+### ✅ Context-Aware
+- Remembers what you've rejected and seen across the whole session
+
+---

--- a/mcp-agents/TMDB-Agent/README.md
+++ b/mcp-agents/TMDB-Agent/README.md
@@ -1,0 +1,346 @@
+# 🎬 TMDB Agent for Agentverse
+
+**A conversational movie and TV recommendation uAgent that maps natural-language moods to real streaming picks — powered by TMDB via a custom MCP server, discoverable on ASI:One through the chat protocol.**
+
+![Architecture](https://img.shields.io/badge/Architecture-MCP%20Server%20in%20uAgent-blue)
+![Protocol](https://img.shields.io/badge/Protocol-Chat%20Protocol-green)
+![MCP](https://img.shields.io/badge/MCP-TMDB%20API-orange)
+![AI](https://img.shields.io/badge/AI-ASI%3AOne-purple)
+
+---
+
+## 🏗️ Detailed Architecture
+
+```
+┌─────────────────────┐
+│    ASI:One LLM      │
+│   (Chat Interface)  │
+└─────────┬───────────┘
+          │ Chat Protocol
+          ▼
+┌─────────────────────┐
+│      uAgent         │
+│  ┌───────────────┐  │
+│  │ Chat Protocol │  │  ◄─── Handles ASI:One communication
+│  │   Handler     │  │
+│  └───────┬───────┘  │
+│          │          │
+│  ┌───────▼───────┐  │
+│  │  Intake &     │  │  ◄─── Mood extraction + session state
+│  │  Intent Layer │  │
+│  └───────┬───────┘  │
+│          │          │
+│  ┌───────▼───────┐  │
+│  │  Tool-Use     │  │  ◄─── ASI:One drives tool selection
+│  │  Loop (ASI1)  │  │
+│  └───────┬───────┘  │
+└──────────┬──────────┘
+           │ async tool calls
+           ▼
+┌─────────────────────┐
+│   TMDB MCP Tools    │
+│ ┌─────────────────┐ │
+│ │  resolve_mood   │ │  ◄─── Vibe → genre IDs + sort
+│ │  search_movies  │ │  ◄─── Title → TMDB ID
+│ │  get_similar    │ │  ◄─── Similarity chains
+│ │  get_trending   │ │  ◄─── Freshness signal
+│ │  check_watch_   │ │  ◄─── Live streaming availability
+│ │  providers      │ │
+│ └─────────────────┘ │
+└─────────┬───────────┘
+          │
+          ▼
+┌─────────────────────┐
+│    TMDB REST API    │
+│  (movies, TV, watch │
+│    providers)       │
+└─────────────────────┘
+```
+
+---
+
+## 🎯 What We Built: MCP Tool Layer → uAgent Wrapper
+
+### The Architecture: Custom MCP Server Inside a uAgent
+
+We built a **FastMCP server** (`tonights_pick_mcp/`) that exposes TMDB as typed async tools. The uAgent (`agent/agent.py`) imports these tools directly as plain async functions and drives them via an **ASI:One tool-use loop**:
+
+```
+User message
+     │
+     ▼
+Intake extraction (mood, who, reference, runtime)
+     │
+     ▼
+ASI:One tool-use loop
+  │  ├── resolve_mood(vibe) → candidate list
+  │  ├── get_similar(movie_id) → similar titles
+  │  ├── check_watch_providers([ids], country) → streaming data
+  │  └── finish(picks) → structured raw data
+     │
+     ▼
+Deterministic formatter → final reply
+```
+
+The `@mcp.tool()` decoration is ignored when the tools are imported directly — the same functions serve both the FastMCP stdio server (for Claude Desktop) and the uAgent runtime.
+
+---
+
+## 🔧 Mood-to-TMDB Pipeline
+
+### How a vibe becomes a recommendation
+
+```python
+# 1. User says: "something dark and slow-burn"
+# 2. Intake layer extracts vibe = "slow-burn"
+# 3. resolve_mood("slow-burn") calls mood_map.py:
+
+VIBE_MAP["slow-burn"] = {
+    "genres": [53, 18],          # thriller, drama
+    "keywords": ["slow burn", "psychological"],
+    "sort": "vote_average.desc",
+}
+
+# 4. TMDB discover endpoint:
+params = {
+    "with_genres": "53,18",
+    "sort_by": "vote_average.desc",
+    "vote_count.gte": 200,
+}
+
+# 5. Concurrent watch-provider lookup via asyncio.gather:
+results = await asyncio.gather(
+    *[_fetch_providers_for_movie(mid, country) for mid in movie_ids]
+)
+```
+
+### Supported Vibes
+
+| Vibe | Genres | Sort |
+|---|---|---|
+| `on-edge` | Thriller, Crime | vote_average |
+| `slow-burn` | Thriller, Drama | vote_average |
+| `dark` | Horror, Thriller, Crime | vote_average |
+| `intense` | Action, Thriller | popularity |
+| `feel-good` | Comedy, Romance | popularity |
+| `romantic` | Romance, Comedy | vote_average |
+| `cosy` | Comedy, Family | popularity |
+| `mind-bending` | Sci-Fi, Thriller | vote_average |
+| `scary` | Horror | popularity |
+| `funny` | Comedy | popularity |
+| `action-packed` | Action, Adventure | popularity |
+| `tearjerker` | Drama, Romance | vote_average |
+
+Aliases like *tense*, *gripping*, *chill*, *trippy*, *emotional*, *sad* resolve automatically.
+
+---
+
+## 🧠 ASI:One Tool-Use Loop
+
+### How the agent decides what to call
+
+The agent sends all 8 movie tools (or 6 TV tools) plus a `finish` function to ASI:One with `tool_choice="required"`. ASI:One drives the full tool-call chain — the agent just executes each call and feeds results back:
+
+```python
+async def run_tool_loop(messages, state):
+    for iteration in range(15):
+        response = await asi1_client.chat.completions.create(
+            model="asi1",
+            messages=loop_messages,
+            tools=tool_schemas,
+            tool_choice="required",
+        )
+        
+        for tc in tool_calls:
+            if tc.function.name == "finish":
+                return _format_picks(fn_args["picks"])  # deterministic formatter
+            
+            result = await tool_functions[tc.function.name](**fn_args)
+            loop_messages.append(tool_result(tc.id, result))
+```
+
+After 8 tool calls the agent nudges ASI:One to call `finish`. After 10 it hard-forces it.
+
+### The `finish` tool
+
+ASI:One never writes the user-facing text. It calls `finish` with structured raw data:
+
+```json
+{
+  "picks": [
+    {
+      "vibe": "slow-burn dread",
+      "title": "Prisoners",
+      "runtime": "153 min",
+      "reason": "Relentless tension and moral ambiguity — closest to Parasite's unease",
+      "streaming": "Max"
+    }
+  ]
+}
+```
+
+The agent's `_format_picks()` converts this to the final reply. Every pick looks identical regardless of which ASI:One run produced it.
+
+---
+
+## 💾 Session State
+
+All conversation state is stored in `ctx.storage` (Agentverse persistent KV store):
+
+| Key | Type | Description |
+|---|---|---|
+| `vibe` | str | Primary mood extracted from user input |
+| `vibe2` | str | Second mood for mixed-mood group sessions |
+| `who` | str | Viewing context: solo, partner, family, friends |
+| `reference` | str | Reference title: *"loved Parasite"* |
+| `rejections` | JSON list | TMDB IDs the user has rejected |
+| `seen_titles` | JSON list | Titles to always skip |
+| `watchlist` | JSON list | Saved picks |
+| `media_type` | str | `"movie"` or `"tv"` |
+| `max_runtime` | int | Runtime cap in minutes |
+| `history` | JSON list | Full `{role, content}` conversation turns |
+
+### Special Intents (handled without LLM calls)
+
+| Phrase | Action |
+|---|---|
+| `"save The Dark Knight"` | Adds to watchlist |
+| `"show my watchlist"` | Returns saved picks |
+| `"mark Parasite as seen"` | Adds to seen list, skipped forever |
+| `"show my seen list"` | Returns seen titles |
+
+---
+
+## 🌐 ASI:One Integration
+
+### Chat Protocol Setup
+
+```python
+from uagents_core.contrib.protocols.chat import (
+    ChatMessage, ChatAcknowledgement, TextContent,
+    StartSessionContent, EndSessionContent, chat_protocol_spec,
+)
+
+agent = Agent(
+    name="tonights-pick",
+    seed=AGENT_SEED,
+    port=8001,
+    mailbox=True,           # REQUIRED for ASI:One discoverability
+)
+
+chat_proto = Protocol(spec=chat_protocol_spec)
+
+@chat_proto.on_message(ChatMessage)
+async def on_chat_message(ctx, sender, msg):
+    # Acknowledge immediately
+    await ctx.send(sender, ChatAcknowledgement(...))
+    
+    # Extract text, run intake + tool loop, reply
+    user_text = extract_text(msg)
+    state = _load_state(ctx)
+    state = _extract_intake(user_text, state)
+    
+    if _intake_complete(state):
+        reply = await run_tool_loop(state["history"], state)
+    else:
+        reply = ask_for_missing_intake()
+    
+    _save_state(ctx, state)
+    await ctx.send(sender, ChatMessage(content=[TextContent(text=reply)]))
+
+agent.include(chat_proto)
+```
+
+---
+
+## 📋 Complete Requirements & Setup
+
+### Requirements
+
+```txt
+uagents==0.24.0
+uagents-core==0.4.4
+openai==2.30.0
+httpx==0.28.1
+pydantic==2.12.5
+python-dotenv==1.2.2
+fastmcp==3.2.0
+```
+
+### Environment Variables
+
+```env
+TMDB_API_KEY=your_tmdb_api_key_here        # from themoviedb.org (free)
+ASI_ONE_API_KEY=your_asi1_key_here         # from asi1.ai
+AGENT_SEED=your-agent-seed-string          # any string, keep stable
+AGENT_PORT=8001                            # local dev port
+```
+
+### Setup
+
+```bash
+# 1. Clone and install
+git clone https://github.com/your-username/tonights-pick.git
+cd tonights-pick
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+
+# 2. Set environment variables
+cp .env.example .env
+# Fill in TMDB_API_KEY and ASI_ONE_API_KEY
+
+# 3. Run the agent locally
+python agent/agent.py
+
+# 4. Or run via Docker
+docker compose -f docker/docker-compose.yml up --build
+```
+
+### TMDB API Key
+
+Get a free key at [themoviedb.org/settings/api](https://www.themoviedb.org/settings/api). The v3 key is used.
+
+---
+
+## 🎛️ MCP Server (Claude Desktop / Google ADK)
+
+The same TMDB tools also run as a standalone FastMCP server over stdio:
+
+```json
+{
+  "mcpServers": {
+    "tonights-pick": {
+      "command": "tonights-pick-mcp",
+      "env": { "TMDB_API_KEY": "your_key" }
+    }
+  }
+}
+```
+
+This makes all 13 TMDB tools available inside Claude Desktop — the uAgent and MCP server share the exact same tool implementations.
+
+---
+
+## 📚 Additional Resources
+
+- **uAgents Framework**: [innovationlab.fetch.ai/resources/docs/agent-creation](https://innovationlab.fetch.ai/resources/docs/agent-creation/uagent-creation)
+- **Chat Protocol**: [innovationlab.fetch.ai/resources/docs/agent-communication](https://innovationlab.fetch.ai/resources/docs/agent-communication/agent-chat-protocol)
+- **ASI:One Platform**: [asi1.ai](https://asi1.ai)
+- **Agentverse Console**: [agentverse.ai](https://agentverse.ai)
+- **TMDB API Docs**: [developers.themoviedb.org](https://developers.themoviedb.org/3)
+- **FastMCP**: [github.com/jlowin/fastmcp](https://github.com/jlowin/fastmcp)
+
+---
+
+## 🎊 Conclusion
+
+The TMDB Agent demonstrates how to build a **production-quality conversational recommendation agent** on Agentverse:
+
+- **🤖 uAgent Framework**: ASI:One discoverability via chat protocol
+- **🔌 FastMCP Tool Layer**: TMDB exposed as typed async tools, usable by both the uAgent and Claude Desktop
+- **🧠 ASI:One Tool-Use Loop**: LLM drives tool selection; agent executes and formats
+- **⚡ Concurrent I/O**: All watch-provider lookups fire simultaneously via `asyncio.gather`
+- **💾 Persistent Session**: Rejections, watchlist, and seen titles survive across turns
+
+**Built using uAgents, FastMCP, TMDB API, and ASI:One.**

--- a/mcp-agents/TMDB-Agent/agent.py
+++ b/mcp-agents/TMDB-Agent/agent.py
@@ -18,34 +18,35 @@ Session state stored in ctx.storage:
   watchlist   — JSON list of {label, text} saved recommendation sets
   seen_titles — JSON list of movie/show titles already seen
 """
+
 from __future__ import annotations
 import json
 import os
+import pathlib
 import re
-import asyncio
+import sys
+from datetime import datetime, timezone
 from typing import Any
+from uuid import uuid4
 
 from dotenv import load_dotenv
+
 load_dotenv()
 
-from uagents import Agent, Context, Protocol
-from uagents.setup import fund_agent_if_low
-from uagents_core.contrib.protocols.chat import (
-    AgentContent,
+from uagents import Agent, Context, Protocol  # noqa: E402
+from uagents.setup import fund_agent_if_low  # noqa: E402
+from uagents_core.contrib.protocols.chat import (  # noqa: E402
     ChatAcknowledgement,
     ChatMessage,
-    EndSessionContent,
     StartSessionContent,
     TextContent,
     chat_protocol_spec,
 )
+from openai import AsyncOpenAI  # noqa: E402
 
-from openai import AsyncOpenAI
-
-import sys, pathlib
 sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
 
-from tonights_pick_mcp.tools import (
+from tonights_pick_mcp.tools import (  # noqa: E402
     search_movies,
     get_similar,
     get_recommendations,
@@ -54,7 +55,6 @@ from tonights_pick_mcp.tools import (
     search_by_keyword,
     get_movie_details,
     check_watch_providers,
-    # TV tools
     search_tv,
     get_similar_tv,
     get_tv_details,
@@ -159,7 +159,10 @@ MOVIE_TOOL_SCHEMAS: list[dict] = [
                 "properties": {
                     "vibe": {"type": "string"},
                     "limit": {"type": "integer", "default": 10},
-                    "max_runtime": {"type": "integer", "description": "Max runtime in minutes"},
+                    "max_runtime": {
+                        "type": "integer",
+                        "description": "Max runtime in minutes",
+                    },
                 },
                 "required": ["vibe"],
             },
@@ -173,8 +176,16 @@ MOVIE_TOOL_SCHEMAS: list[dict] = [
             "parameters": {
                 "type": "object",
                 "properties": {
-                    "media_type": {"type": "string", "enum": ["movie", "tv"], "default": "movie"},
-                    "window": {"type": "string", "enum": ["day", "week"], "default": "week"},
+                    "media_type": {
+                        "type": "string",
+                        "enum": ["movie", "tv"],
+                        "default": "movie",
+                    },
+                    "window": {
+                        "type": "string",
+                        "enum": ["day", "week"],
+                        "default": "week",
+                    },
                     "limit": {"type": "integer", "default": 10},
                 },
             },
@@ -240,11 +251,26 @@ MOVIE_TOOL_SCHEMAS: list[dict] = [
                         "items": {
                             "type": "object",
                             "properties": {
-                                "vibe":      {"type": "string", "description": "Short vibe label, e.g. 'slow-burn dread'"},
-                                "title":     {"type": "string", "description": "Movie title only, no year"},
-                                "runtime":   {"type": "string", "description": "Runtime, e.g. '119 min'"},
-                                "reason":    {"type": "string", "description": "One sentence why this fits"},
-                                "streaming": {"type": "string", "description": "Streaming service name(s)"},
+                                "vibe": {
+                                    "type": "string",
+                                    "description": "Short vibe label, e.g. 'slow-burn dread'",
+                                },
+                                "title": {
+                                    "type": "string",
+                                    "description": "Movie title only, no year",
+                                },
+                                "runtime": {
+                                    "type": "string",
+                                    "description": "Runtime, e.g. '119 min'",
+                                },
+                                "reason": {
+                                    "type": "string",
+                                    "description": "One sentence why this fits",
+                                },
+                                "streaming": {
+                                    "type": "string",
+                                    "description": "Streaming service name(s)",
+                                },
                             },
                             "required": ["vibe", "title", "reason", "streaming"],
                         },
@@ -329,7 +355,11 @@ TV_TOOL_SCHEMAS: list[dict] = [
                 "type": "object",
                 "properties": {
                     "media_type": {"type": "string", "enum": ["tv"], "default": "tv"},
-                    "window": {"type": "string", "enum": ["day", "week"], "default": "week"},
+                    "window": {
+                        "type": "string",
+                        "enum": ["day", "week"],
+                        "default": "week",
+                    },
                     "limit": {"type": "integer", "default": 10},
                 },
             },
@@ -363,11 +393,26 @@ TV_TOOL_SCHEMAS: list[dict] = [
                         "items": {
                             "type": "object",
                             "properties": {
-                                "vibe":      {"type": "string", "description": "Short vibe label, e.g. 'slow-burn dread'"},
-                                "title":     {"type": "string", "description": "Show title only"},
-                                "runtime":   {"type": "string", "description": "e.g. '3 seasons, ~45 min/ep'"},
-                                "reason":    {"type": "string", "description": "One sentence why this fits"},
-                                "streaming": {"type": "string", "description": "Streaming service name(s)"},
+                                "vibe": {
+                                    "type": "string",
+                                    "description": "Short vibe label, e.g. 'slow-burn dread'",
+                                },
+                                "title": {
+                                    "type": "string",
+                                    "description": "Show title only",
+                                },
+                                "runtime": {
+                                    "type": "string",
+                                    "description": "e.g. '3 seasons, ~45 min/ep'",
+                                },
+                                "reason": {
+                                    "type": "string",
+                                    "description": "One sentence why this fits",
+                                },
+                                "streaming": {
+                                    "type": "string",
+                                    "description": "Streaming service name(s)",
+                                },
                             },
                             "required": ["vibe", "title", "reason", "streaming"],
                         },
@@ -443,6 +488,7 @@ You can also:
 # Storage helpers
 # ---------------------------------------------------------------------------
 
+
 def _load_state(ctx: Context) -> dict:
     return {
         "vibe": ctx.storage.get("vibe") or "",
@@ -478,6 +524,7 @@ def _save_state(ctx: Context, state: dict) -> None:
 # Intent detection (runs before normal intake)
 # ---------------------------------------------------------------------------
 
+
 def _detect_special_intent(text: str) -> str | None:
     """Return a special intent string or None for normal recommendation flow."""
     lower = text.lower()
@@ -497,9 +544,15 @@ def _detect_special_intent(text: str) -> str | None:
 
     # --- Show watchlist ---
     watchlist_show = [
-        "show watchlist", "show my watchlist", "show wishlist", "show my wishlist",
-        "what's saved", "what did i save", "show my list",
-        "my watchlist", "my wishlist",
+        "show watchlist",
+        "show my watchlist",
+        "show wishlist",
+        "show my wishlist",
+        "what's saved",
+        "what did i save",
+        "show my list",
+        "my watchlist",
+        "my wishlist",
     ]
     if any(p in lower for p in watchlist_show):
         return "show_watchlist"
@@ -520,7 +573,7 @@ def _extract_specific_title(text: str) -> str | None:
     if cleaned and cleaned not in {"it", "that", "them", "those", "this"}:
         idx = text.lower().find(cleaned)
         if idx != -1:
-            return text[idx: idx + len(cleaned)].strip(".,!?")
+            return text[idx : idx + len(cleaned)].strip(".,!?")
     return None
 
 
@@ -529,6 +582,7 @@ def _extract_mark_seen_title(text: str) -> str | None:
     m = re.search(r"\bmark\s+(.+?)\s+as\s+(?:seen|watched)\b", text, re.IGNORECASE)
     if m:
         return m.group(1).strip().strip(".,!?")
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -536,10 +590,23 @@ def _extract_mark_seen_title(text: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 _VIBE_KEYWORDS = [
-    "on-edge", "slow-burn", "dark", "intense", "feel-good",
-    "romantic", "cosy", "cozy", "mind-bending", "scary",
-    "funny", "action-packed", "tearjerker", "thriller",
-    "comedy", "horror", "drama",
+    "on-edge",
+    "slow-burn",
+    "dark",
+    "intense",
+    "feel-good",
+    "romantic",
+    "cosy",
+    "cozy",
+    "mind-bending",
+    "scary",
+    "funny",
+    "action-packed",
+    "tearjerker",
+    "thriller",
+    "comedy",
+    "horror",
+    "drama",
 ]
 
 
@@ -548,14 +615,25 @@ def _extract_intake(text: str, state: dict) -> dict:
     lower = text.lower()
 
     # --- media_type (TV mode) ---
-    tv_signals = ["binge", "series", "tv show", "tv series", "show me a show",
-                  "something to watch on tv", "a series", "episodes"]
+    tv_signals = [
+        "binge",
+        "series",
+        "tv show",
+        "tv series",
+        "show me a show",
+        "something to watch on tv",
+        "a series",
+        "episodes",
+    ]
     if any(s in lower for s in tv_signals):
         state["media_type"] = "tv"
 
     # --- who ---
     if not state["who"]:
-        if any(w in lower for w in ["partner", "girlfriend", "boyfriend", "wife", "husband", "date"]):
+        if any(
+            w in lower
+            for w in ["partner", "girlfriend", "boyfriend", "wife", "husband", "date"]
+        ):
             state["who"] = "partner"
         elif any(w in lower for w in ["solo", "alone", "myself", "by myself"]):
             state["who"] = "solo"
@@ -573,11 +651,19 @@ def _extract_intake(text: str, state: dict) -> dict:
 
     # --- second vibe (we can't agree / mixed mood) ---
     if not state["vibe2"] and state["vibe"]:
-        for trigger in ["they want", "she wants", "he wants", "partner wants",
-                        "friend wants", "but also", "mix of", "and also"]:
+        for trigger in [
+            "they want",
+            "she wants",
+            "he wants",
+            "partner wants",
+            "friend wants",
+            "but also",
+            "mix of",
+            "and also",
+        ]:
             idx = lower.find(trigger)
             if idx != -1:
-                remainder = text[idx + len(trigger):].strip()
+                remainder = text[idx + len(trigger) :].strip()
                 for kw in _VIBE_KEYWORDS:
                     if kw in remainder.lower():
                         if kw != state["vibe"]:
@@ -593,38 +679,61 @@ def _extract_intake(text: str, state: dict) -> dict:
     # --- runtime cap ---
     if state["max_runtime"] is None:
         # "under 2 hours", "less than 2 hours"
-        m = re.search(r'(?:under|less than|max|within|no more than)\s+(\d+(?:\.\d+)?)\s*(?:hour|hr)', lower)
+        m = re.search(
+            r"(?:under|less than|max|within|no more than)\s+(\d+(?:\.\d+)?)\s*(?:hour|hr)",
+            lower,
+        )
         if m:
             state["max_runtime"] = int(float(m.group(1)) * 60)
         else:
             # "under 90 minutes"
-            m = re.search(r'(?:under|less than|max|within|no more than)\s+(\d+)\s*(?:minute|min)', lower)
+            m = re.search(
+                r"(?:under|less than|max|within|no more than)\s+(\d+)\s*(?:minute|min)",
+                lower,
+            )
             if m:
                 state["max_runtime"] = int(m.group(1))
-            elif "short film" in lower or "quick watch" in lower or "short movie" in lower:
+            elif (
+                "short film" in lower
+                or "quick watch" in lower
+                or "short movie" in lower
+            ):
                 state["max_runtime"] = 90
 
     # --- reference movie/show ---
     if not state["reference"]:
-        for trigger in ["loved ", "like ", "enjoyed ", "watched ", "similar to ", "fan of "]:
+        for trigger in [
+            "loved ",
+            "like ",
+            "enjoyed ",
+            "watched ",
+            "similar to ",
+            "fan of ",
+        ]:
             # only pick up as reference if NOT preceded by "i've" / "already"
             idx = lower.find(trigger)
             if idx != -1:
-                pre = lower[max(0, idx - 10):idx]
+                pre = lower[max(0, idx - 10) : idx]
                 if "seen" in pre or "already" in pre or "i've" in pre:
                     continue
-                remainder = text[idx + len(trigger):]
+                remainder = text[idx + len(trigger) :]
                 words = remainder.split()[:5]
                 state["reference"] = " ".join(words).strip(".,!?")
                 break
 
     # --- seen-it list ---
-    seen_triggers = ["i've seen ", "i have seen ", "already seen ", "already watched ",
-                     "seen it", "i saw "]
+    seen_triggers = [
+        "i've seen ",
+        "i have seen ",
+        "already seen ",
+        "already watched ",
+        "seen it",
+        "i saw ",
+    ]
     for trigger in seen_triggers:
         idx = lower.find(trigger)
         if idx != -1 and trigger not in ("seen it",):
-            remainder = text[idx + len(trigger):]
+            remainder = text[idx + len(trigger) :]
             words = remainder.split()[:5]
             title = " ".join(words).strip(".,!?")
             if title and title not in state["seen_titles"]:
@@ -641,6 +750,7 @@ def _intake_complete(state: dict) -> bool:
 # ---------------------------------------------------------------------------
 # Tool-use loop
 # ---------------------------------------------------------------------------
+
 
 def _build_system_prompt(state: dict) -> str:
     base = _TV_SYSTEM_PROMPT if state["media_type"] == "tv" else _MOVIE_SYSTEM_PROMPT
@@ -674,20 +784,26 @@ def _format_picks(picks: list[dict]) -> str:
     """Deterministic formatting — LLM supplies raw data, we control every character."""
     lines = []
     for p in picks:
-        vibe      = p.get("vibe", "").strip()
-        title     = p.get("title", "").strip()
-        runtime   = p.get("runtime", "").strip()
-        reason    = p.get("reason", "").strip().rstrip(".")
+        vibe = p.get("vibe", "").strip()
+        title = p.get("title", "").strip()
+        runtime = p.get("runtime", "").strip()
+        reason = p.get("reason", "").strip().rstrip(".")
         streaming = p.get("streaming", "").strip()
         runtime_part = f" ({runtime})" if runtime else ""
-        lines.append(f"• **{vibe}** *{title}*{runtime_part} — {reason}. Stream on: {streaming}")
+        lines.append(
+            f"• **{vibe}** *{title}*{runtime_part} — {reason}. Stream on: {streaming}"
+        )
     return "\n\n".join(lines)
 
 
 async def run_tool_loop(messages: list[dict], state: dict) -> str:
     """Call ASI1 with tool schemas; execute tool calls until finish is called."""
-    tool_functions = TV_TOOL_FUNCTIONS if state["media_type"] == "tv" else MOVIE_TOOL_FUNCTIONS
-    tool_schemas = TV_TOOL_SCHEMAS if state["media_type"] == "tv" else MOVIE_TOOL_SCHEMAS
+    tool_functions = (
+        TV_TOOL_FUNCTIONS if state["media_type"] == "tv" else MOVIE_TOOL_FUNCTIONS
+    )
+    tool_schemas = (
+        TV_TOOL_SCHEMAS if state["media_type"] == "tv" else MOVIE_TOOL_SCHEMAS
+    )
     finish_only = [s for s in tool_schemas if s["function"]["name"] == "finish"]
 
     system_msg = {"role": "system", "content": _build_system_prompt(state)}
@@ -696,25 +812,27 @@ async def run_tool_loop(messages: list[dict], state: dict) -> str:
     tool_call_count = 0
     FORCE_FINISH_AFTER = 8  # inject a nudge; hard-force finish after 10
 
-    for iteration in range(15):
+    for _ in range(15):
         # After threshold, force the model to call finish
         if tool_call_count >= FORCE_FINISH_AFTER:
-            loop_messages.append({
-                "role": "user",
-                "content": (
-                    "You have gathered enough information. "
-                    "Stop searching and call finish NOW with your best picks. "
-                    "Include rent/buy options if streaming isn't available."
-                ),
-            })
-            response = await asi1_client.chat.completions.create(
+            loop_messages.append(
+                {
+                    "role": "user",
+                    "content": (
+                        "You have gathered enough information. "
+                        "Stop searching and call finish NOW with your best picks. "
+                        "Include rent/buy options if streaming isn't available."
+                    ),
+                }
+            )
+            response = await asi1_client.chat.completions.create(  # type: ignore[call-overload]
                 model=ASI1_MODEL,
                 messages=loop_messages,
                 tools=finish_only,
                 tool_choice={"type": "function", "function": {"name": "finish"}},
             )
         else:
-            response = await asi1_client.chat.completions.create(
+            response = await asi1_client.chat.completions.create(  # type: ignore[call-overload]
                 model=ASI1_MODEL,
                 messages=loop_messages,
                 tools=tool_schemas,
@@ -725,20 +843,27 @@ async def run_tool_loop(messages: list[dict], state: dict) -> str:
         tool_calls = choice.message.tool_calls or []
 
         if not tool_calls:
-            return choice.message.content or "Sorry, I ran into trouble. Please try again."
+            return (
+                choice.message.content or "Sorry, I ran into trouble. Please try again."
+            )
 
-        loop_messages.append({
-            "role": "assistant",
-            "content": None,
-            "tool_calls": [
-                {
-                    "id": tc.id,
-                    "type": "function",
-                    "function": {"name": tc.function.name, "arguments": tc.function.arguments},
-                }
-                for tc in tool_calls
-            ],
-        })
+        loop_messages.append(
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.function.name,
+                            "arguments": tc.function.arguments,
+                        },
+                    }
+                    for tc in tool_calls
+                ],
+            }
+        )
 
         for tc in tool_calls:
             fn_name = tc.function.name
@@ -760,11 +885,13 @@ async def run_tool_loop(messages: list[dict], state: dict) -> str:
                 except Exception as exc:
                     result = json.dumps({"error": str(exc)})
 
-            loop_messages.append({
-                "role": "tool",
-                "tool_call_id": tc.id,
-                "content": result,
-            })
+            loop_messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tc.id,
+                    "content": result,
+                }
+            )
 
     return "Sorry, I ran into trouble finding good picks. Please try again."
 
@@ -773,10 +900,13 @@ async def run_tool_loop(messages: list[dict], state: dict) -> str:
 # Special intent handlers
 # ---------------------------------------------------------------------------
 
+
 def _handle_show_watchlist(state: dict) -> str:
     if not state["watchlist"]:
         return "Your watchlist is empty. After I give you recommendations, say 'save it' or 'save [title]' to add picks."
-    lines = [f"Your watchlist ({len(state['watchlist'])} title{'s' if len(state['watchlist']) != 1 else ''}):\n"]
+    lines = [
+        f"Your watchlist ({len(state['watchlist'])} title{'s' if len(state['watchlist']) != 1 else ''}):\n"
+    ]
     for i, item in enumerate(state["watchlist"], 1):
         lines.append(f"{i}. {item['title']}")
     return "\n".join(lines)
@@ -785,7 +915,7 @@ def _handle_show_watchlist(state: dict) -> str:
 def _handle_save_watchlist(state: dict, user_text: str = "") -> str:
     title = _extract_specific_title(user_text) if user_text else None
     if not title:
-        return "Tell me which title to save — e.g. \"save The Dark Knight\"."
+        return 'Tell me which title to save — e.g. "save The Dark Knight".'
     already = [w["title"].lower() for w in state["watchlist"]]
     if title.lower() not in already:
         state["watchlist"].append({"title": title})
@@ -813,9 +943,6 @@ def _handle_show_seen(state: dict) -> str:
 # Message helpers
 # ---------------------------------------------------------------------------
 
-from datetime import datetime, timezone
-from uuid import uuid4
-
 
 def _make_chat_message(text: str) -> ChatMessage:
     return ChatMessage(
@@ -828,6 +955,7 @@ def _make_chat_message(text: str) -> ChatMessage:
 # ---------------------------------------------------------------------------
 # Message handler
 # ---------------------------------------------------------------------------
+
 
 @chat_proto.on_message(ChatAcknowledgement)
 async def on_ack(ctx: Context, sender: str, msg: ChatAcknowledgement) -> None:

--- a/mcp-agents/TMDB-Agent/agent.py
+++ b/mcp-agents/TMDB-Agent/agent.py
@@ -635,7 +635,7 @@ def _extract_intake(text: str, state: dict) -> dict:
 
 
 def _intake_complete(state: dict) -> bool:
-    return bool(state["vibe"] and state["who"])
+    return bool(state["vibe"])
 
 
 # ---------------------------------------------------------------------------
@@ -895,7 +895,7 @@ async def on_chat_message(ctx: Context, sender: str, msg: ChatMessage) -> None:
         content_type = "show" if state["media_type"] == "tv" else "movie"
         follow_up = (
             f"What's the vibe tonight — on-edge, slow-burn, dark, funny, romantic? "
-            f"And who are you watching with? Any {content_type} you loved recently?"
+            f"Any {content_type} you loved recently?"
         )
         state["history"].append({"role": "assistant", "content": follow_up})
         _save_state(ctx, state)

--- a/mcp-agents/TMDB-Agent/agent.py
+++ b/mcp-agents/TMDB-Agent/agent.py
@@ -1,0 +1,918 @@
+"""Tonight's Pick — uAgent deployed on Fetch.ai Agentverse.
+
+Conversation flow:
+  1. User describes mood/context.
+  2. Agent asks one follow-up (vibe + reference movie) if intake incomplete.
+  3. Agent calls ASI1 with tool schemas; executes the tool-use loop.
+  4. Agent replies with 3-4 picks grouped by vibe.
+
+Session state stored in ctx.storage:
+  vibe        — e.g. "on-edge"
+  vibe2       — optional second vibe for "we can't agree" mode
+  who         — e.g. "partner", "solo", "family"
+  reference   — e.g. "Parasite"
+  rejections  — JSON list of movie IDs the user has rejected
+  history     — JSON list of {role, content} conversation turns
+  media_type  — "movie" (default) or "tv"
+  max_runtime — optional int (minutes) for time-boxed discovery
+  watchlist   — JSON list of {label, text} saved recommendation sets
+  seen_titles — JSON list of movie/show titles already seen
+"""
+from __future__ import annotations
+import json
+import os
+import re
+import asyncio
+from typing import Any
+
+from dotenv import load_dotenv
+load_dotenv()
+
+from uagents import Agent, Context, Protocol
+from uagents.setup import fund_agent_if_low
+from uagents_core.contrib.protocols.chat import (
+    AgentContent,
+    ChatAcknowledgement,
+    ChatMessage,
+    EndSessionContent,
+    StartSessionContent,
+    TextContent,
+    chat_protocol_spec,
+)
+
+from openai import AsyncOpenAI
+
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent))
+
+from tonights_pick_mcp.tools import (
+    search_movies,
+    get_similar,
+    get_recommendations,
+    resolve_mood,
+    get_trending,
+    search_by_keyword,
+    get_movie_details,
+    check_watch_providers,
+    # TV tools
+    search_tv,
+    get_similar_tv,
+    get_tv_details,
+    resolve_mood_tv,
+    check_tv_watch_providers,
+)
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+ASI1_API_KEY = os.environ.get("ASI_ONE_API_KEY", "")
+ASI1_BASE_URL = "https://api.asi1.ai/v1"
+ASI1_MODEL = "asi1"
+AGENT_SEED = os.environ.get("AGENT_SEED", "tonights-pick-agent-seed-v1")
+AGENT_PORT = int(os.environ.get("AGENT_PORT", 8001))
+
+asi1_client = AsyncOpenAI(api_key=ASI1_API_KEY, base_url=ASI1_BASE_URL)
+
+# ---------------------------------------------------------------------------
+# Tool registries
+# ---------------------------------------------------------------------------
+
+MOVIE_TOOL_FUNCTIONS: dict[str, Any] = {
+    "search_movies": search_movies,
+    "get_similar": get_similar,
+    "get_recommendations": get_recommendations,
+    "resolve_mood": resolve_mood,
+    "get_trending": get_trending,
+    "search_by_keyword": search_by_keyword,
+    "get_movie_details": get_movie_details,
+    "check_watch_providers": check_watch_providers,
+}
+
+TV_TOOL_FUNCTIONS: dict[str, Any] = {
+    "search_tv": search_tv,
+    "get_similar_tv": get_similar_tv,
+    "get_tv_details": get_tv_details,
+    "resolve_mood_tv": resolve_mood_tv,
+    "get_trending": get_trending,
+    "check_tv_watch_providers": check_tv_watch_providers,
+}
+
+MOVIE_TOOL_SCHEMAS: list[dict] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "search_movies",
+            "description": "Search TMDB for movies matching a title. Use to resolve a title to its TMDB ID.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "limit": {"type": "integer", "default": 5},
+                },
+                "required": ["query"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_similar",
+            "description": "Get movies similar to a given TMDB movie ID.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "movie_id": {"type": "integer"},
+                    "limit": {"type": "integer", "default": 10},
+                },
+                "required": ["movie_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_recommendations",
+            "description": "Get TMDB personalised recommendations for a movie ID.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "movie_id": {"type": "integer"},
+                    "limit": {"type": "integer", "default": 10},
+                },
+                "required": ["movie_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "resolve_mood",
+            "description": (
+                "Discover movies matching a mood/vibe. "
+                "Vibes: on-edge, slow-burn, dark, intense, feel-good, romantic, "
+                "cosy, mind-bending, scary, funny, action-packed, tearjerker. "
+                "Pass max_runtime (minutes) to enforce a runtime cap."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "vibe": {"type": "string"},
+                    "limit": {"type": "integer", "default": 10},
+                    "max_runtime": {"type": "integer", "description": "Max runtime in minutes"},
+                },
+                "required": ["vibe"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_trending",
+            "description": "Fetch trending movies or TV shows this week.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "media_type": {"type": "string", "enum": ["movie", "tv"], "default": "movie"},
+                    "window": {"type": "string", "enum": ["day", "week"], "default": "week"},
+                    "limit": {"type": "integer", "default": 10},
+                },
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "search_by_keyword",
+            "description": "Find movies tagged with a keyword (e.g. 'heist', 'revenge', 'psychological').",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "keyword": {"type": "string"},
+                    "limit": {"type": "integer", "default": 10},
+                },
+                "required": ["keyword"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_movie_details",
+            "description": "Get full details (runtime, genres, tagline) for a single TMDB movie ID.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "movie_id": {"type": "integer"},
+                },
+                "required": ["movie_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "check_watch_providers",
+            "description": (
+                "Check streaming availability for a list of movie IDs. "
+                "country: ISO 3166-1 alpha-2 (e.g. 'US', 'GB')."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "movie_ids": {"type": "array", "items": {"type": "integer"}},
+                    "country": {"type": "string", "default": "US"},
+                },
+                "required": ["movie_ids"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "finish",
+            "description": "Call this when you have your final picks. Supply raw data only — no formatting.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "picks": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "vibe":      {"type": "string", "description": "Short vibe label, e.g. 'slow-burn dread'"},
+                                "title":     {"type": "string", "description": "Movie title only, no year"},
+                                "runtime":   {"type": "string", "description": "Runtime, e.g. '119 min'"},
+                                "reason":    {"type": "string", "description": "One sentence why this fits"},
+                                "streaming": {"type": "string", "description": "Streaming service name(s)"},
+                            },
+                            "required": ["vibe", "title", "reason", "streaming"],
+                        },
+                    },
+                },
+                "required": ["picks"],
+            },
+        },
+    },
+]
+
+TV_TOOL_SCHEMAS: list[dict] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "search_tv",
+            "description": "Search TMDB for TV shows matching a title. Use to resolve a title to its TMDB ID.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "limit": {"type": "integer", "default": 5},
+                },
+                "required": ["query"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_similar_tv",
+            "description": "Get TV shows similar to a given TMDB show ID.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "tv_id": {"type": "integer"},
+                    "limit": {"type": "integer", "default": 10},
+                },
+                "required": ["tv_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_tv_details",
+            "description": "Get full details (seasons, episode runtime, genres) for a TMDB TV show ID.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "tv_id": {"type": "integer"},
+                },
+                "required": ["tv_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "resolve_mood_tv",
+            "description": (
+                "Discover TV shows matching a mood/vibe. "
+                "Vibes: on-edge, slow-burn, dark, intense, feel-good, romantic, "
+                "cosy, mind-bending, scary, funny, action-packed, tearjerker."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "vibe": {"type": "string"},
+                    "limit": {"type": "integer", "default": 10},
+                },
+                "required": ["vibe"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_trending",
+            "description": "Fetch trending TV shows this week.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "media_type": {"type": "string", "enum": ["tv"], "default": "tv"},
+                    "window": {"type": "string", "enum": ["day", "week"], "default": "week"},
+                    "limit": {"type": "integer", "default": 10},
+                },
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "check_tv_watch_providers",
+            "description": "Check streaming availability for a list of TV show IDs.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "tv_ids": {"type": "array", "items": {"type": "integer"}},
+                    "country": {"type": "string", "default": "US"},
+                },
+                "required": ["tv_ids"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "finish",
+            "description": "Call this when you have your final picks. Supply raw data only — no formatting.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "picks": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "vibe":      {"type": "string", "description": "Short vibe label, e.g. 'slow-burn dread'"},
+                                "title":     {"type": "string", "description": "Show title only"},
+                                "runtime":   {"type": "string", "description": "e.g. '3 seasons, ~45 min/ep'"},
+                                "reason":    {"type": "string", "description": "One sentence why this fits"},
+                                "streaming": {"type": "string", "description": "Streaming service name(s)"},
+                            },
+                            "required": ["vibe", "title", "reason", "streaming"],
+                        },
+                    },
+                },
+                "required": ["picks"],
+            },
+        },
+    },
+]
+
+# ---------------------------------------------------------------------------
+# System prompts
+# ---------------------------------------------------------------------------
+
+_MOVIE_SYSTEM_PROMPT = """You are Tonight's Pick — a conversational movie recommendation agent.
+
+Your goal: find 3-4 streaming-ready movies that match the user's mood and viewing context.
+
+Rules:
+- Resolve reference titles to IDs first, then use those IDs.
+- Use at most 2-3 discovery calls (resolve_mood, get_similar, search_by_keyword), then stop.
+- Call check_watch_providers ONCE on all candidates together.
+- Only recommend movies available on at least one streaming service.
+- Get runtime via get_movie_details for your final picks.
+- Never recommend a movie the user has already rejected or already seen.
+- Call finish with raw data fields (vibe, title, runtime, reason, streaming). Do not format anything.
+- Never call more than 6 tools total.
+"""
+
+_TV_SYSTEM_PROMPT = """You are Tonight's Pick — a conversational TV show recommendation agent.
+
+Your goal: find 3-4 streaming-ready TV shows that match the user's mood and viewing context.
+
+Rules:
+- Resolve reference show titles to IDs first.
+- Use at most 2-3 discovery calls (resolve_mood_tv, get_similar_tv), then stop.
+- Call check_tv_watch_providers ONCE on all candidates together.
+- Only recommend shows available on at least one streaming service.
+- Get seasons/runtime via get_tv_details for your final picks.
+- Never recommend a show the user has already rejected or already seen.
+- Call finish with raw data fields (vibe, title, runtime, reason, streaming). Do not format anything.
+- Never call more than 6 tools total.
+"""
+
+# ---------------------------------------------------------------------------
+# uAgent setup
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    name="tonights-pick",
+    seed=AGENT_SEED,
+    port=AGENT_PORT,
+    mailbox=True,
+)
+
+fund_agent_if_low(agent.wallet.address())
+
+chat_proto = Protocol(spec=chat_protocol_spec)
+
+FEATURE_HINT = """
+
+You can also:
+- Save a pick: "save [title]"
+- View your watchlist: "show my watchlist"
+- Skip titles you've seen: "mark [title] as seen"
+- Filter by runtime: "under 90 minutes"
+- Switch to TV: "something to binge"
+- Mixed moods: "I want dark, they want romantic"
+"""
+
+# ---------------------------------------------------------------------------
+# Storage helpers
+# ---------------------------------------------------------------------------
+
+def _load_state(ctx: Context) -> dict:
+    return {
+        "vibe": ctx.storage.get("vibe") or "",
+        "vibe2": ctx.storage.get("vibe2") or "",
+        "who": ctx.storage.get("who") or "",
+        "reference": ctx.storage.get("reference") or "",
+        "rejections": json.loads(ctx.storage.get("rejections") or "[]"),
+        "history": json.loads(ctx.storage.get("history") or "[]"),
+        "media_type": ctx.storage.get("media_type") or "movie",
+        "max_runtime": ctx.storage.get("max_runtime"),
+        "watchlist": json.loads(ctx.storage.get("watchlist") or "[]"),
+        "seen_titles": json.loads(ctx.storage.get("seen_titles") or "[]"),
+        "last_reply": ctx.storage.get("last_reply") or "",
+    }
+
+
+def _save_state(ctx: Context, state: dict) -> None:
+    ctx.storage.set("vibe", state["vibe"])
+    ctx.storage.set("vibe2", state["vibe2"])
+    ctx.storage.set("who", state["who"])
+    ctx.storage.set("reference", state["reference"])
+    ctx.storage.set("rejections", json.dumps(state["rejections"]))
+    ctx.storage.set("history", json.dumps(state["history"]))
+    ctx.storage.set("media_type", state["media_type"])
+    if state["max_runtime"] is not None:
+        ctx.storage.set("max_runtime", state["max_runtime"])
+    ctx.storage.set("watchlist", json.dumps(state["watchlist"]))
+    ctx.storage.set("seen_titles", json.dumps(state["seen_titles"]))
+    ctx.storage.set("last_reply", state["last_reply"])
+
+
+# ---------------------------------------------------------------------------
+# Intent detection (runs before normal intake)
+# ---------------------------------------------------------------------------
+
+def _detect_special_intent(text: str) -> str | None:
+    """Return a special intent string or None for normal recommendation flow."""
+    lower = text.lower()
+
+    # --- Mark as seen (check before save to avoid conflicts) ---
+    if re.search(r"\bmark\b.+\bas\s+(?:seen|watched)\b", lower):
+        return "add_seen"
+
+    # --- Save to watchlist — specific title only ---
+    # "save [title] to my watchlist/wishlist" or just "save [title]"
+    if re.search(r"\bto\s+(my\s+|the\s+)?(watch|wish)list\b", lower):
+        return "save_watchlist"
+
+    # "save <specific title>" — starts with save + a non-pronoun word
+    if re.match(r"^save\s+(?!it\b|that\b|them\b|those\b|this\b)\w", lower):
+        return "save_watchlist"
+
+    # --- Show watchlist ---
+    watchlist_show = [
+        "show watchlist", "show my watchlist", "show wishlist", "show my wishlist",
+        "what's saved", "what did i save", "show my list",
+        "my watchlist", "my wishlist",
+    ]
+    if any(p in lower for p in watchlist_show):
+        return "show_watchlist"
+
+    # --- Show seen list ---
+    seen_show = ["show seen", "what have i seen", "my seen list", "show my seen"]
+    if any(p in lower for p in seen_show):
+        return "show_seen"
+
+    return None
+
+
+def _extract_specific_title(text: str) -> str | None:
+    """Pull a specific title out of 'save X to my watchlist/wishlist' style messages."""
+    lower = text.lower()
+    cleaned = re.sub(r"\s+to\s+(my\s+|the\s+)?(watch|wish)list.*$", "", lower).strip()
+    cleaned = re.sub(r"^(save|add)\s+", "", cleaned).strip()
+    if cleaned and cleaned not in {"it", "that", "them", "those", "this"}:
+        idx = text.lower().find(cleaned)
+        if idx != -1:
+            return text[idx: idx + len(cleaned)].strip(".,!?")
+    return None
+
+
+def _extract_mark_seen_title(text: str) -> str | None:
+    """Pull title from 'mark X as seen/watched' messages."""
+    m = re.search(r"\bmark\s+(.+?)\s+as\s+(?:seen|watched)\b", text, re.IGNORECASE)
+    if m:
+        return m.group(1).strip().strip(".,!?")
+
+
+# ---------------------------------------------------------------------------
+# Intake extraction
+# ---------------------------------------------------------------------------
+
+_VIBE_KEYWORDS = [
+    "on-edge", "slow-burn", "dark", "intense", "feel-good",
+    "romantic", "cosy", "cozy", "mind-bending", "scary",
+    "funny", "action-packed", "tearjerker", "thriller",
+    "comedy", "horror", "drama",
+]
+
+
+def _extract_intake(text: str, state: dict) -> dict:
+    """Extract vibe/who/reference/media_type/max_runtime/vibe2/seen from user text."""
+    lower = text.lower()
+
+    # --- media_type (TV mode) ---
+    tv_signals = ["binge", "series", "tv show", "tv series", "show me a show",
+                  "something to watch on tv", "a series", "episodes"]
+    if any(s in lower for s in tv_signals):
+        state["media_type"] = "tv"
+
+    # --- who ---
+    if not state["who"]:
+        if any(w in lower for w in ["partner", "girlfriend", "boyfriend", "wife", "husband", "date"]):
+            state["who"] = "partner"
+        elif any(w in lower for w in ["solo", "alone", "myself", "by myself"]):
+            state["who"] = "solo"
+        elif any(w in lower for w in ["family", "kids", "children"]):
+            state["who"] = "family"
+        elif any(w in lower for w in ["friend", "friends", "mates", "group"]):
+            state["who"] = "friends"
+
+    # --- primary vibe ---
+    if not state["vibe"]:
+        for kw in _VIBE_KEYWORDS:
+            if kw in lower:
+                state["vibe"] = kw
+                break
+
+    # --- second vibe (we can't agree / mixed mood) ---
+    if not state["vibe2"] and state["vibe"]:
+        for trigger in ["they want", "she wants", "he wants", "partner wants",
+                        "friend wants", "but also", "mix of", "and also"]:
+            idx = lower.find(trigger)
+            if idx != -1:
+                remainder = text[idx + len(trigger):].strip()
+                for kw in _VIBE_KEYWORDS:
+                    if kw in remainder.lower():
+                        if kw != state["vibe"]:
+                            state["vibe2"] = kw
+                        break
+                break
+        # Fallback: two distinct vibes both appear in the message
+        if not state["vibe2"]:
+            found = [kw for kw in _VIBE_KEYWORDS if kw in lower]
+            if len(found) >= 2 and found[1] != state["vibe"]:
+                state["vibe2"] = found[1]
+
+    # --- runtime cap ---
+    if state["max_runtime"] is None:
+        # "under 2 hours", "less than 2 hours"
+        m = re.search(r'(?:under|less than|max|within|no more than)\s+(\d+(?:\.\d+)?)\s*(?:hour|hr)', lower)
+        if m:
+            state["max_runtime"] = int(float(m.group(1)) * 60)
+        else:
+            # "under 90 minutes"
+            m = re.search(r'(?:under|less than|max|within|no more than)\s+(\d+)\s*(?:minute|min)', lower)
+            if m:
+                state["max_runtime"] = int(m.group(1))
+            elif "short film" in lower or "quick watch" in lower or "short movie" in lower:
+                state["max_runtime"] = 90
+
+    # --- reference movie/show ---
+    if not state["reference"]:
+        for trigger in ["loved ", "like ", "enjoyed ", "watched ", "similar to ", "fan of "]:
+            # only pick up as reference if NOT preceded by "i've" / "already"
+            idx = lower.find(trigger)
+            if idx != -1:
+                pre = lower[max(0, idx - 10):idx]
+                if "seen" in pre or "already" in pre or "i've" in pre:
+                    continue
+                remainder = text[idx + len(trigger):]
+                words = remainder.split()[:5]
+                state["reference"] = " ".join(words).strip(".,!?")
+                break
+
+    # --- seen-it list ---
+    seen_triggers = ["i've seen ", "i have seen ", "already seen ", "already watched ",
+                     "seen it", "i saw "]
+    for trigger in seen_triggers:
+        idx = lower.find(trigger)
+        if idx != -1 and trigger not in ("seen it",):
+            remainder = text[idx + len(trigger):]
+            words = remainder.split()[:5]
+            title = " ".join(words).strip(".,!?")
+            if title and title not in state["seen_titles"]:
+                state["seen_titles"].append(title)
+            break
+
+    return state
+
+
+def _intake_complete(state: dict) -> bool:
+    return bool(state["vibe"] and state["who"])
+
+
+# ---------------------------------------------------------------------------
+# Tool-use loop
+# ---------------------------------------------------------------------------
+
+def _build_system_prompt(state: dict) -> str:
+    base = _TV_SYSTEM_PROMPT if state["media_type"] == "tv" else _MOVIE_SYSTEM_PROMPT
+    extras: list[str] = []
+
+    if state["rejections"]:
+        extras.append(f"Already rejected IDs (do not recommend): {state['rejections']}")
+
+    if state["seen_titles"]:
+        titles = ", ".join(f'"{t}"' for t in state["seen_titles"])
+        extras.append(f"User has already seen these — do NOT recommend them: {titles}")
+
+    if state["max_runtime"] and state["media_type"] == "movie":
+        extras.append(
+            f"RUNTIME CONSTRAINT: Only recommend movies under {state['max_runtime']} minutes. "
+            f"Pass max_runtime={state['max_runtime']} to resolve_mood. Verify runtime via get_movie_details for final picks."
+        )
+
+    if state["vibe2"]:
+        extras.append(
+            f"MIXED MOOD: The user wants '{state['vibe']}' but their companion wants '{state['vibe2']}'. "
+            f"Find picks that satisfy BOTH vibes — look for genre overlaps or films/shows that blend both moods."
+        )
+
+    if extras:
+        base += "\n\n" + "\n".join(extras)
+    return base
+
+
+def _format_picks(picks: list[dict]) -> str:
+    """Deterministic formatting — LLM supplies raw data, we control every character."""
+    lines = []
+    for p in picks:
+        vibe      = p.get("vibe", "").strip()
+        title     = p.get("title", "").strip()
+        runtime   = p.get("runtime", "").strip()
+        reason    = p.get("reason", "").strip().rstrip(".")
+        streaming = p.get("streaming", "").strip()
+        runtime_part = f" ({runtime})" if runtime else ""
+        lines.append(f"• **{vibe}** *{title}*{runtime_part} — {reason}. Stream on: {streaming}")
+    return "\n\n".join(lines)
+
+
+async def run_tool_loop(messages: list[dict], state: dict) -> str:
+    """Call ASI1 with tool schemas; execute tool calls until finish is called."""
+    tool_functions = TV_TOOL_FUNCTIONS if state["media_type"] == "tv" else MOVIE_TOOL_FUNCTIONS
+    tool_schemas = TV_TOOL_SCHEMAS if state["media_type"] == "tv" else MOVIE_TOOL_SCHEMAS
+    finish_only = [s for s in tool_schemas if s["function"]["name"] == "finish"]
+
+    system_msg = {"role": "system", "content": _build_system_prompt(state)}
+    loop_messages = [system_msg] + messages
+
+    tool_call_count = 0
+    FORCE_FINISH_AFTER = 8  # inject a nudge; hard-force finish after 10
+
+    for iteration in range(15):
+        # After threshold, force the model to call finish
+        if tool_call_count >= FORCE_FINISH_AFTER:
+            loop_messages.append({
+                "role": "user",
+                "content": (
+                    "You have gathered enough information. "
+                    "Stop searching and call finish NOW with your best picks. "
+                    "Include rent/buy options if streaming isn't available."
+                ),
+            })
+            response = await asi1_client.chat.completions.create(
+                model=ASI1_MODEL,
+                messages=loop_messages,
+                tools=finish_only,
+                tool_choice={"type": "function", "function": {"name": "finish"}},
+            )
+        else:
+            response = await asi1_client.chat.completions.create(
+                model=ASI1_MODEL,
+                messages=loop_messages,
+                tools=tool_schemas,
+                tool_choice="required",
+            )
+
+        choice = response.choices[0]
+        tool_calls = choice.message.tool_calls or []
+
+        if not tool_calls:
+            return choice.message.content or "Sorry, I ran into trouble. Please try again."
+
+        loop_messages.append({
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {"name": tc.function.name, "arguments": tc.function.arguments},
+                }
+                for tc in tool_calls
+            ],
+        })
+
+        for tc in tool_calls:
+            fn_name = tc.function.name
+            fn_args = json.loads(tc.function.arguments)
+
+            if fn_name == "finish":
+                picks = fn_args.get("picks", [])
+                if picks:
+                    return _format_picks(picks)
+                return "Sorry, I ran into trouble finding good picks. Please try again."
+
+            tool_call_count += 1
+            fn = tool_functions.get(fn_name)
+            if fn is None:
+                result = json.dumps({"error": f"Unknown tool: {fn_name}"})
+            else:
+                try:
+                    result = await fn(**fn_args)
+                except Exception as exc:
+                    result = json.dumps({"error": str(exc)})
+
+            loop_messages.append({
+                "role": "tool",
+                "tool_call_id": tc.id,
+                "content": result,
+            })
+
+    return "Sorry, I ran into trouble finding good picks. Please try again."
+
+
+# ---------------------------------------------------------------------------
+# Special intent handlers
+# ---------------------------------------------------------------------------
+
+def _handle_show_watchlist(state: dict) -> str:
+    if not state["watchlist"]:
+        return "Your watchlist is empty. After I give you recommendations, say 'save it' or 'save [title]' to add picks."
+    lines = [f"Your watchlist ({len(state['watchlist'])} title{'s' if len(state['watchlist']) != 1 else ''}):\n"]
+    for i, item in enumerate(state["watchlist"], 1):
+        lines.append(f"{i}. {item['title']}")
+    return "\n".join(lines)
+
+
+def _handle_save_watchlist(state: dict, user_text: str = "") -> str:
+    title = _extract_specific_title(user_text) if user_text else None
+    if not title:
+        return "Tell me which title to save — e.g. \"save The Dark Knight\"."
+    already = [w["title"].lower() for w in state["watchlist"]]
+    if title.lower() not in already:
+        state["watchlist"].append({"title": title})
+    current = ", ".join(w["title"] for w in state["watchlist"])
+    return f"Saved {title} to your watchlist!\n\nCurrent watchlist: {current}"
+
+
+def _handle_add_seen(state: dict, user_text: str) -> str:
+    title = _extract_mark_seen_title(user_text)
+    if title:
+        if title.lower() not in [s.lower() for s in state["seen_titles"]]:
+            state["seen_titles"].append(title)
+        return f"Got it — I'll skip **{title}** in all future recommendations."
+    return "Which title should I mark as seen? Just tell me the name."
+
+
+def _handle_show_seen(state: dict) -> str:
+    if not state["seen_titles"]:
+        return "Your seen list is empty. Tell me 'I've seen X' and I'll remember to skip it."
+    titles = "\n".join(f"- {t}" for t in state["seen_titles"])
+    return f"Movies/shows you've marked as seen:\n{titles}"
+
+
+# ---------------------------------------------------------------------------
+# Message helpers
+# ---------------------------------------------------------------------------
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+
+def _make_chat_message(text: str) -> ChatMessage:
+    return ChatMessage(
+        timestamp=datetime.now(timezone.utc),
+        msg_id=uuid4(),
+        content=[TextContent(type="text", text=text)],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Message handler
+# ---------------------------------------------------------------------------
+
+@chat_proto.on_message(ChatAcknowledgement)
+async def on_ack(ctx: Context, sender: str, msg: ChatAcknowledgement) -> None:
+    ctx.logger.info(f"Acknowledgement from {sender} for {msg.acknowledged_msg_id}")
+
+
+@chat_proto.on_message(ChatMessage)
+async def on_chat_message(ctx: Context, sender: str, msg: ChatMessage) -> None:
+    await ctx.send(
+        sender,
+        ChatAcknowledgement(
+            timestamp=datetime.now(timezone.utc),
+            acknowledged_msg_id=msg.msg_id,
+        ),
+    )
+
+    if any(isinstance(item, StartSessionContent) for item in msg.content):
+        ctx.logger.info(f"Session started by {sender}")
+
+    user_text = " ".join(
+        item.text for item in msg.content if isinstance(item, TextContent)
+    ).strip()
+    # Strip leading @mentions (Agentverse includes the handle in the message text)
+    user_text = re.sub(r"^(@\w[\w.-]*\s*)+", "", user_text).strip()
+    if not user_text:
+        return
+
+    state = _load_state(ctx)
+    state["history"].append({"role": "user", "content": user_text})
+
+    # --- Special intent handling (watchlist / seen list) ---
+    intent = _detect_special_intent(user_text)
+    if intent == "show_watchlist":
+        reply = _handle_show_watchlist(state)
+        state["history"].append({"role": "assistant", "content": reply})
+        _save_state(ctx, state)
+        await ctx.send(sender, _make_chat_message(reply))
+        return
+
+    if intent == "save_watchlist":
+        reply = _handle_save_watchlist(state, user_text)
+        state["history"].append({"role": "assistant", "content": reply})
+        _save_state(ctx, state)
+        await ctx.send(sender, _make_chat_message(reply))
+        return
+
+    if intent == "add_seen":
+        reply = _handle_add_seen(state, user_text)
+        state["history"].append({"role": "assistant", "content": reply})
+        _save_state(ctx, state)
+        await ctx.send(sender, _make_chat_message(reply))
+        return
+
+    if intent == "show_seen":
+        reply = _handle_show_seen(state)
+        state["history"].append({"role": "assistant", "content": reply})
+        _save_state(ctx, state)
+        await ctx.send(sender, _make_chat_message(reply))
+        return
+
+    # --- Normal intake extraction ---
+    state = _extract_intake(user_text, state)
+
+    if not _intake_complete(state):
+        content_type = "show" if state["media_type"] == "tv" else "movie"
+        follow_up = (
+            f"What's the vibe tonight — on-edge, slow-burn, dark, funny, romantic? "
+            f"And who are you watching with? Any {content_type} you loved recently?"
+        )
+        state["history"].append({"role": "assistant", "content": follow_up})
+        _save_state(ctx, state)
+        await ctx.send(sender, _make_chat_message(follow_up))
+        return
+
+    # --- Run tool-use loop ---
+    reply_text = await run_tool_loop(state["history"], state)
+    state["last_reply"] = reply_text
+    state["history"].append({"role": "assistant", "content": reply_text})
+    outgoing = reply_text + FEATURE_HINT
+    _save_state(ctx, state)
+
+    await ctx.send(sender, _make_chat_message(outgoing))
+
+
+agent.include(chat_proto)
+
+if __name__ == "__main__":
+    agent.run()

--- a/mcp-agents/TMDB-Agent/requirements.txt
+++ b/mcp-agents/TMDB-Agent/requirements.txt
@@ -1,0 +1,7 @@
+uagents==0.24.0
+uagents-core==0.4.4
+openai==2.30.0
+httpx==0.28.1
+pydantic==2.12.5
+python-dotenv==1.2.2
+fastmcp==3.2.0


### PR DESCRIPTION
## TMDB Agent

Adds a conversational movie and TV recommendation uAgent to `mcp-agents/`.

### What it does
- Translates natural-language moods into TMDB-powered picks with live streaming availability
- Supports 12 vibes (on-edge, slow-burn, dark, feel-good, etc.) plus aliases
- Covers both movies and TV shows
- Session memory: rejections, seen titles, watchlist across turns
- Runtime filtering, mixed-mood group sessions

### Files added
- `agent.py` — uAgent with ASI:One tool-use loop and chat protocol
- `requirements.txt` — Python dependencies
- `README.md` — Architecture, pipeline walkthrough, setup guide
- `Agent-Profile.md` — Agentverse agent overview

### Stack
- Fetch.ai uAgents + ASI:One
- FastMCP server over TMDB REST API
- `asyncio.gather` for concurrent watch-provider lookups