### PR TITLE
fix: resolve incorrect and missing example references in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to this repository are documented in this file.
 - `.dockerignore` for clean Docker builds
 - `.github/workflows/ci.yml` — push-to-main CI (lint, format, architecture, test)
 - Tagging and categorization guidelines in `CONTRIBUTING.md`
-- Missing `requirements.txt` for `community_agent`, `av-script-example`, `asi1-llm-example`, `advance-agent-examples/{search,policy,basic}_agent`
+- Missing `requirements.txt` for `community_agent`, `av-script-example`, `asi1-llm-example`, `google-adk/{search,policy,basic}_agent`
 - Missing `.env.example` for `community_agent`, `duffel-agent`, `deploy-agent-on-av`, `asi-cloud-agent`, `pdf-summariser-example`, `flight-tracker-openai-workflow-agent`, `google-genai-parallel-processing/brand-management-agent`, `Rag-agent/ango`, `asi1-llm-example`
 - Missing `README.md` for `duffel-agent`, `deploy-agent-on-av`
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ innovation-lab-examples/
 │   └── ISSUE_TEMPLATE/
 │
 ├── fetch-hackathon-quickstarter/   # Start here!
-├── advance-agent-examples/         # Advanced patterns
+├── google-adk/                     # Google ADK agent patterns
 ├── gemini-quickstart/              # Google Gemini series
 ├── anthropic-quickstart/           # Claude series
 ├── ...                             # 30+ examples below
@@ -141,9 +141,10 @@ innovation-lab-examples/
 
 | Example | Description | Tech Stack | Difficulty |
 |---------|-------------|------------|------------|
-| [advance-agent-examples](advance-agent-examples/) | Advanced patterns — sub-agents, search, policy, security, SEO, due diligence | Python, uAgents, Google ADK | 🟡–🔴 Collection |
+| [google-adk](google-adk/) | Google ADK patterns — sub-agents, search, policy, security, SEO, due diligence | Python, uAgents, Google ADK | 🟡–🔴 Collection |
 | [Crewai-agents](Crewai-agents/) | CrewAI agents — trip planner, code analyzer, meeting prep, blood report | Python, CrewAI, uAgents | 🟡–🔴 Collection |
 | [ag2-agents](ag2-agents/) | AG2 framework — research synthesis, payment approval | Python, AG2, uAgents | 🔴 Advanced |
+| [video-to-map-agent](video-to-map-agent/) | Multi-video travel itinerary planner with maps, weather, PDF/Excel, and Stripe | Python, uAgents, ASI:One, Stripe, Google Maps | 🔴 Advanced |
 | [community_agent](community_agent/) | AI community growth agent for events and hackathons | Python, uAgents, ASI:One, Tavily | 🟡 Intermediate |
 
 ### 🌐 Web3 & Blockchain


### PR DESCRIPTION
## Summary

This PR resolves incorrect and missing references in the main `README.md` and `CHANGELOG.md` files:
1. Replaces the invalid folder reference `advance-agent-examples` with the correct `google-adk` folder path.
2. Adds the missing `video-to-map-agent` entry under the `Multi-Agent Systems` section in the examples index.

## Type of Change

- [x] Documentation update

## Checklist

- [x] I have starred this repository.
- [x] I updated `CHANGELOG.md` (required for non-doc changes).
- [x] I verified paths/commands used in docs.

## Related Issue

Fixes #34

## Notes for Reviewers

N/A
