### PR TITLE
fix(trip_planner): replace unsafe eval() in calculator tool with AST …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ All notable changes to this repository are documented in this file.
 - Missing `README.md` for `duffel-agent`, `deploy-agent-on-av`
 
 
+### Fixed
+
+- `Crewai-agents/trip_planner/tools/calculator_tools.py`: replace unsafe `eval()` in `CalculatorTools.calculate` with AST-based math evaluation so LLM-supplied input cannot execute arbitrary Python code
+
 ### Changed
 
 - `README.md` rewritten with project overview, quickstart guide, categorized examples index table, folder structure, Docker instructions, and resource links

--- a/Crewai-agents/trip_planner/tools/calculator_tools.py
+++ b/Crewai-agents/trip_planner/tools/calculator_tools.py
@@ -1,15 +1,50 @@
+import ast
+import operator
+import re
 from langchain.tools import tool
+
+_ALLOWED_CHARS = re.compile(r"^[0-9+\-*/().\s]+$")
+_BIN_OPS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+}
+
+
+def _eval_math_node(node: ast.AST) -> float:
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+        return float(node.value)
+    if isinstance(node, ast.BinOp) and type(node.op) in _BIN_OPS:
+        left = _eval_math_node(node.left)
+        right = _eval_math_node(node.right)
+        if isinstance(node.op, ast.Div) and right == 0:
+            raise ZeroDivisionError("division by zero")
+        return _BIN_OPS[type(node.op)](left, right)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        return -_eval_math_node(node.operand)
+    raise ValueError("unsupported expression")
+
+
+def _safe_eval_math(expression: str) -> float:
+    expr = expression.strip()
+    if not expr or not _ALLOWED_CHARS.match(expr):
+        raise ValueError("invalid characters")
+    tree = ast.parse(expr, mode="eval")
+    return _eval_math_node(tree.body)
 
 
 class CalculatorTools:
     @tool("Make a calculation")
-    def calculate(operation):
+    def calculate(operation: str):
         """Useful to perform any mathematical calculations,
         like sum, minus, multiplication, division, etc.
         The input to this tool should be a mathematical
         expression, a couple examples are `200*7` or `5000/2*10`
         """
         try:
-            return eval(operation)
-        except SyntaxError:
+            return _safe_eval_math(operation)
+        except ZeroDivisionError:
+            return "Error: Division by zero"
+        except (SyntaxError, ValueError, TypeError, OverflowError):
             return "Error: Invalid syntax in mathematical expression"


### PR DESCRIPTION
## Summary

Fixes a **critical security issue** in `Crewai-agents/trip_planner/tools/calculator_tools.py` where `CalculatorTools.calculate` passed LLM-controlled input to Python `eval()`, enabling arbitrary code execution (RCE).

This PR replaces `eval()` with a safe math evaluator that:
- Allows only digits, whitespace, and `+ - * / ( ) .`
- Parses expressions with `ast.parse(..., mode="eval")`
- Evaluates a restricted AST (constants, binary ops, unary minus)
- Returns clear errors for invalid input and division by zero


## Type of Change

- [ ] New agent example
- [x] Bug fix
- [x] Documentation update
- [x] Refactor / cleanup
- [x] Other

## Checklist

- [x] I have starred this repository.
- [ ] I ran `ruff check .`.
- [ ] I ran `ruff format .`.
- [x] I added/updated `README.md` for changed example(s). *(Not required — behavior unchanged for valid math input; security fix only.)*
- [x] I added `.env.example` if environment variables are required. *(N/A)*
- [ ] I added demo image/GIF (if applicable). *(N/A)*
- [ ] I added agent profile link (if applicable). *(N/A)*
- [x] I updated `CHANGELOG.md` (required for non-doc changes).
- [x] I verified paths/commands used in docs.

## Related Issue

Closes #111 


## Notes for Reviewers

### Security

| Before | After |
|--------|--------|
| `eval(operation)` with full Python builtins | Whitelist + AST-only evaluation |
| Payloads like `__import__('os').system('id')` execute | Rejected with `ValueError` → user-facing error string |

### Files changed

- `Crewai-agents/trip_planner/tools/calculator_tools.py` — core fix
- `CHANGELOG.md` — unreleased fix entry

### Behavior preserved

Valid examples from the tool docstring still work, e.g. `200*7` → `1400.0`, `5000/2*10` → `25000.0`.
