### PR TITLE
feat: add news-card-agent (ASI:One interactive cards example)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this repository are documented in this file.
 ## [Unreleased]
 
 ### Added
+- `news-card-agent/`: ASI:One interactive-cards example. Live news rendered as a `card_kind: "custom"` element-tree (section → list of items with image, heading, text, badge, and a "Read Full Article" button). Tapping a button opens a fresh detail card. Multi-backend news cascade (Tavily → NewsAPI.org → Hacker News), ASI1 LLM-polished card copy, and no payment protocol.
 - Auto badge workflow [award-contributor-badge.yml](.github/workflows/award-contributor-badge.yml) for merged external contributor PRs; [BADGE_REGISTRY.json](contributors/BADGE_REGISTRY.json) and [profile-badge-sync](contributors/profile-badge-sync/) for GitHub Profile README
 - Maintainer bypass for `review-required` and `stargazer-gate` (Fetch.ai org, repo write access, [.github/MAINTAINERS](.github/MAINTAINERS))
 - GitHub issues #54–#91 for intermediate bugs, docs, and `ai-agent-idea` challenges

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ innovation-lab-examples/
 | Example | Description | Tech Stack | Difficulty |
 |---------|-------------|------------|------------|
 | [asi1-llm-example](asi1-llm-example/) | ASI:One LLM with LangChain integration | Python, LangChain, ASI:One | 🟢 Beginner |
+| [news-card-agent](news-card-agent/) | Live news rendered as ASI:One interactive cards (custom element-tree) with Tavily + ASI1 polish | Python, uAgents, ASI:One, Tavily, Cards | 🟡 Intermediate |
 | [anthropic-quickstart](anthropic-quickstart/) | Claude integration series — basic, vision, functions, MCP, multi-agent | Python, Anthropic SDK, uAgents | 🟢–🔴 Series |
 | [gemini-quickstart](gemini-quickstart/) | Google Gemini series — text, Imagen, Veo, Lyria, TTS, research, film | Python, Google Gemini, uAgents | 🟢–🔴 Series |
 | [openai-agent-sdk](openai-agent-sdk/) | OpenAI Agents SDK examples (scholarship finder) | Python, OpenAI SDK, uAgents | 🟡 Intermediate |

--- a/news-card-agent/.env.example
+++ b/news-card-agent/.env.example
@@ -1,0 +1,23 @@
+# Agent identity
+AGENT_NAME=News Card Agent
+AGENT_SEED_PHRASE=news-card-agent-seed
+AGENT_PORT=8000
+
+# ASI1 One LLM (used to polish card subtitles & intro lines)
+# Get one at https://asi1.ai
+ASI_ONE_API_KEY=
+ASI_ONE_MODEL=asi1-mini
+
+# Tavily web-search API (preferred news backend) - https://app.tavily.com/home
+# Free dev keys look like: tvly-dev-xxxxxxxxxxxxxxxxxxxxxx
+TAVILY_API_KEY=
+
+# NewsAPI.org - used only if TAVILY_API_KEY is empty.
+# Get a free dev key at https://newsapi.org
+NEWS_API_KEY=
+# Country filter for NewsAPI top-headlines. Use "any" (or leave blank) for
+# no country filter — the agent will route the request through /everything.
+NEWS_API_COUNTRY=any
+
+# If both TAVILY_API_KEY and NEWS_API_KEY are empty, the agent falls back to
+# the public Hacker News API (no key required).

--- a/news-card-agent/README.md
+++ b/news-card-agent/README.md
@@ -1,0 +1,351 @@
+# News Card Agent
+
+![uagents](https://img.shields.io/badge/uagents-4A90E2) ![asi1](https://img.shields.io/badge/asi1-000000) ![agentverse](https://img.shields.io/badge/agentverse-FF6B6B) ![tavily](https://img.shields.io/badge/tavily-7C3AED) ![innovationlab](https://img.shields.io/badge/innovationlab-3D8BD3) ![chatprotocol](https://img.shields.io/badge/chatprotocol-1D3BD4) ![cards](https://img.shields.io/badge/interactive--cards-22C55E)
+
+## 🎯 News Card Agent: A Rich, Interactive News Feed for ASI:One
+
+Want to show news inside ASI:One that **looks like a real app**, not a wall of text? The News Card Agent is a uAgent that replies with **agent-driven interactive cards** — a scrollable list of articles with cover images, headlines, source badges, and a **Read Full Article** button on every item. Tap the button and a brand-new detail card slides in with the full article preview and a clickable link to the source.
+
+It uses [Tavily](https://app.tavily.com/home) for live web-search news, [ASI1 One LLM](https://asi1.ai) to polish each article's subtitle into a single tight sentence, and the [Agentverse element-tree card primitives](https://docs.agentverse.ai/documentation/advanced-usages/element-tree-primitives) to render the UI. **No payment protocol** — pure chat + cards.
+
+### What it Does
+
+This agent takes any free-text news query (e.g. `latest tech news`, `bitcoin news`, `world news`) and replies with a rich card carousel. Each article in the card is selectable — tapping **Read Full Article** triggers a follow-up message back to the agent, which then renders a second card with the article's full body and source link.
+
+## ✨ Key Features
+
+* **Agent-Driven Interactive Cards** - Sends a `MetadataContent` block carrying `card_kind: "custom"` element trees (no plain-text walls)
+* **News List Card** - `section` → `list` of items with image, heading, body text, source badge, and a primary "Read Full Article" button
+* **Article Detail Card** - rendered on button click, with hero image, full description, source link, and a "Back to News" button
+* **Tavily Web Search** - Default backend; live `topic: "news"` search across the web with auto-paired images
+* **Multi-Backend** - Auto-cascades **Tavily → NewsAPI.org → Hacker News** based on which env keys are set; no key required to run
+* **ASI1 LLM Polishing** - Each card subtitle is summarised to one sentence by ASI1 One LLM (with graceful fallback to raw API descriptions)
+* **Selection Round-Trip** - Handles both inbound formats from the chat UI: raw JSON (direct @mention) and natural-language prose (via planner)
+* **Storage-Backed Lookup** - Articles are cached in `ctx.storage` by `article_id` so the detail card can render even if the news API is rate-limited
+* **No Payment Protocol** - Just the standard chat protocol + cards
+
+## 🔧 Setup
+
+### Prerequisites
+
+- Python 3.10 or higher
+- pip (Python package manager)
+- [ASI1 One LLM](https://asi1.ai) API key (recommended — used for subtitle polish)
+- [Tavily](https://app.tavily.com/home) API key (recommended — preferred news backend)
+- _(Optional)_ [NewsAPI.org](https://newsapi.org) key — fallback if Tavily is not set
+
+> If you skip every news key, the agent still works by falling back to the public Hacker News Firebase API (no key required).
+
+### Installation
+
+1. **Clone the repository:**
+```bash
+git clone <repository-url>
+cd news-card-agent
+```
+
+2. **Install dependencies:**
+```bash
+pip install -r requirements.txt
+```
+
+3. **Configure environment variables:**
+
+Create a `.env` file in the project root directory with the following variables:
+
+```env
+# Agent identity
+AGENT_NAME=News Card Agent
+AGENT_SEED_PHRASE=news-card-agent-seed
+AGENT_PORT=8000
+
+# ASI1 One LLM (used to polish card subtitles & intro lines)
+ASI_ONE_API_KEY=your_asi1_api_key_here
+ASI_ONE_MODEL=asi1-mini
+
+# Tavily web-search API (preferred news backend)
+TAVILY_API_KEY=tvly-dev-xxxxxxxxxxxxxxxxxxxxxx
+
+# NewsAPI.org - used only if TAVILY_API_KEY is empty
+NEWS_API_KEY=
+# Country code for NewsAPI top-headlines, or "any" for no country filter
+NEWS_API_COUNTRY=any
+```
+
+**How to get API keys:**
+- **ASI1 One LLM**: Sign up at [ASI1.ai](https://asi1.ai)
+- **Tavily**: Free dev key at [app.tavily.com/home](https://app.tavily.com/home)
+- **NewsAPI.org**: Free dev key at [newsapi.org](https://newsapi.org)
+
+### How to Start
+
+Run the agent with:
+
+```bash
+python agent.py
+```
+
+The agent will start on the following port:
+- **Agent mailbox**: `http://localhost:8000` (registered with Agentverse mailbox)
+
+**To stop the application:** Press `CTRL+C` in the terminal
+
+### Example Queries
+
+```plaintext
+latest news
+```
+
+```plaintext
+latest tech news
+```
+
+```plaintext
+world news today
+```
+
+```plaintext
+bitcoin price news
+```
+
+```plaintext
+SpaceX launch news
+```
+
+```plaintext
+AI agents news
+```
+
+### Expected Response Format
+
+When you ask for news, the agent replies with **two pieces in one ChatMessage**:
+
+1. A `TextContent` preamble (one-line intro generated by ASI1 LLM):
+
+```
+Here are 6 of the latest stories from Tavily.
+```
+
+2. A `MetadataContent` carrying the news list card payload (rendered by ASI:One as a scrollable card):
+
+```json
+{
+  "root": {
+    "type": "section",
+    "title": "Latest News",
+    "subtitle": "Tap an article to read more",
+    "children": [
+      {
+        "type": "list",
+        "items": [
+          {
+            "children": [
+              {"type": "image", "src": "https://...", "aspect_ratio": "16:9"},
+              {"type": "group", "direction": "column", "gap": 8, "children": [
+                {"type": "heading", "value": "<article title>", "level": 3},
+                {"type": "text", "value": "<one-line summary>", "style": "body"},
+                {"type": "badge", "label": "<source>", "variant": "info"}
+              ]},
+              {"type": "button", "label": "Read Full Article", "primary": true,
+               "action": {"selection": {"article_id": "tv_abc123", "source": "news_tab"}}}
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+When the user taps **Read Full Article**, the agent replies with a similar `ChatMessage` carrying the **article detail card** plus a clickable markdown link to the original article.
+
+## 🔧 Technical Architecture
+
+- **Framework**: uAgents + Chat Protocol + Agentverse Interactive Cards
+- **AI Model**: ASI1 One LLM (`asi1-mini` via `https://api.asi1.ai/v1/chat/completions`)
+- **News Backend**: Tavily (default) → NewsAPI.org → Hacker News (auto-cascade)
+- **UI Format**: `card_kind: "custom"` with element-tree primitives (`section`, `list`, `group`, `image`, `heading`, `text`, `badge`, `button`, `divider`)
+- **Storage**: `ctx.storage` keyed by `article_id` for detail-card lookup
+- **Transport**: Mailbox registration via Agentverse
+
+## 📊 Component Overview
+
+### 1. **Agent Entrypoint (`agent.py`)**
+- Loads env early, builds the `Agent` with mailbox registration
+- Includes only the chat protocol (no payment protocol)
+- Logs the active news backend + whether ASI1 is enabled on startup
+
+### 2. **Chat Protocol (`chat_proto.py`)**
+- Acknowledges every inbound message
+- Greets on `StartSessionContent`
+- For `TextContent`:
+  - Tries to parse the text as a card selection JSON first (button click round-trip)
+  - If `action == "back_to_news"` → re-renders the list card for the last query
+  - If `article_id` is present → renders the article detail card
+  - Otherwise treats text as a news query → fetches, summarises, sends list card
+- Caches each article in storage so the detail card can be rendered later
+
+### 3. **Card Builders (`cards.py`)**
+- `build_news_list_payload(articles)` — section/list/items with image+group+button
+- `build_article_detail_payload(article)` — section with hero image, body, source, back button
+- `build_news_list_message()` / `build_article_detail_message()` — wrap payloads into `ChatMessage` with the required `MetadataContent` keys (`card_protocol_version`, `requires_card_interaction`, `card_kind`, `card_payload`)
+
+### 4. **News Client (`news_client.py`)**
+- `_fetch_tavily()` — `POST https://api.tavily.com/search` with `topic: "news"`, `include_images: True`. Pairs images by index, falls back to picsum placeholders
+- `_fetch_newsapi()` — Routes to `/top-headlines` when a country/category is set, otherwise to `/everything` with a generic query (so `NEWS_API_COUNTRY=any` works)
+- `_fetch_hackernews()` — Public Firebase API, no key required
+- `fetch_news()` — Async cascade picker (Tavily → NewsAPI → HN)
+
+### 5. **ASI1 LLM Client (`asi1_client.py`)**
+- `summarise_article()` — one-sentence card subtitle
+- `craft_preamble()` — intro line above the news list card
+- `craft_article_preamble()` — intro line above the article detail card
+- All three degrade gracefully (return raw text fallback) when no API key is set
+
+### 6. **Shared Helpers (`shared.py`)**
+- `create_text_chat()` — simple text-only `ChatMessage` builder
+- `parse_card_selection()` — handles both JSON-as-text and planner prose formats for inbound selections
+
+## 🔄 Agent Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant C as ASI:One Chat
+    participant A as News Card Agent
+    participant T as Tavily / NewsAPI
+    participant L as ASI1 One LLM
+
+    U->>C: "latest tech news"
+    C->>A: ChatMessage(TextContent)
+    A->>C: ChatAcknowledgement
+    A->>T: search topic=news, query="latest tech news"
+    T-->>A: results[] + images[]
+    A->>L: summarise each article (parallel)
+    L-->>A: one-line subtitles
+    A->>A: cache articles in ctx.storage by article_id
+    A->>C: ChatMessage(TextContent + MetadataContent card_kind=custom)
+    C->>U: Render "Latest News" card with list of articles
+
+    U->>C: tap "Read Full Article"
+    C->>A: ChatMessage('{"article_id":"tv_abc","source":"news_tab"}')
+    A->>A: parse selection + lookup article
+    A->>L: craft intro line
+    L-->>A: intro
+    A->>C: ChatMessage(intro + markdown link + detail card)
+    C->>U: Render article detail card
+
+    U->>C: tap "Back to News"
+    C->>A: ChatMessage('{"action":"back_to_news",...}')
+    A->>C: re-send news list card for last query
+```
+
+## 🆘 Troubleshooting
+
+### Common Issues
+
+1. **`ASI_ONE_API_KEY` not set**: The agent still runs — it just falls back to raw API descriptions and a generic preamble. To get LLM-polished subtitles, set the key in `.env`.
+2. **No articles returned**:
+   - If Tavily: confirm `TAVILY_API_KEY` looks like `tvly-dev-...` and you have quota left.
+   - If NewsAPI: the dev tier only allows requests from `localhost` and the registered dev domain.
+   - If Hacker News: should always work unless your network blocks `hacker-news.firebaseio.com`.
+3. **Port Conflicts**: Check if port 8000 is already in use. Kill it with:
+   ```bash
+   lsof -ti:8000 | xargs kill -9
+   ```
+4. **Card not rendering (text shown instead)**: ASI:One falls back to plain text when card validation fails. Check that:
+   - `card_protocol_version: "1"` is set
+   - `card_payload` is JSON-stringified inside the `metadata` dict (not nested as an object)
+   - Element-tree nesting depth ≤ 8 and total payload ≤ 64 KB
+5. **NewsAPI 400 / `parametersMissing`**: NewsAPI's `/top-headlines` requires a country, category, or sources. The agent auto-routes to `/everything` when `NEWS_API_COUNTRY=any` — make sure you're on the latest code.
+
+### Performance Tips
+
+- Tavily and ASI1 calls are fired in parallel via `asyncio.gather`, so adding more articles in `DEFAULT_LIMIT` is cheap.
+- Card subtitles are short by design (under 25 words) — this keeps payload size well below the 64 KB limit.
+- Storage cache survives across messages in the same agent session, so users can scroll up and re-tap any previously shown article.
+
+## 📈 Use Cases
+
+- **News Briefings**: Daily morning summary with tappable headlines
+- **Topic Monitors**: Show "latest news on quantum computing" as a card carousel
+- **ASI:One Demos**: Showcase the agent-driven interactive cards API end-to-end
+- **Card Schema Learning**: Reference implementation of the element-tree primitives (`section`, `list`, `group`, `image`, `heading`, `text`, `badge`, `button`)
+- **Multi-Backend Aggregation**: Drop in a different news source by adding a `_fetch_*` function and registering it in `fetch_news()`
+
+## 🧪 Testing the Agent
+
+### Test via ASI:One Chat
+
+Open the agent's chat page on ASI:One (after the mailbox registers) and send:
+
+```
+latest tech news
+```
+
+You should see a card titled "News · Tech" (or "Latest News") with a list of articles. Tap any **Read Full Article** button — a new card slides in with the article details.
+
+### Test the card payload locally
+
+You can render the JSON payload in the [ASI:One card playground](https://asi1.ai/developer/card-playground) before running the agent:
+
+```python
+import json
+from news_client import Article
+from cards import build_news_list_payload
+
+articles = [
+    Article(
+        article_id="tv_demo1",
+        title="Breakthrough in Quantum Computing Achieved",
+        description="Scientists have successfully demonstrated a new quantum error correction method.",
+        url="https://example.com/article",
+        image_url="https://picsum.photos/seed/technews/800/450",
+        source="example.com",
+        published_at="",
+    ),
+]
+print(json.dumps(build_news_list_payload(articles), indent=2))
+```
+
+### Simulate a button click
+
+In a direct `@mention` flow, the chat UI sends the button's `selection` payload back as a JSON string inside a `TextContent`. You can simulate it by chatting:
+
+```
+{"article_id": "tv_abc123", "source": "news_tab"}
+```
+
+The agent will look the id up in storage and reply with the article detail card.
+
+To simulate the **Back to News** button:
+
+```
+{"action": "back_to_news", "source": "news_tab"}
+```
+
+## 🔒 Supported News Backends
+
+| Priority | Backend | Env var | Image support | Notes |
+| --- | --- | --- | --- | --- |
+| 1 | **Tavily** | `TAVILY_API_KEY` | ✅ | Web search with `topic: "news"`. Free dev tier. |
+| 2 | **NewsAPI.org** | `NEWS_API_KEY` | ✅ (`urlToImage`) | Set `NEWS_API_COUNTRY=any` for no country filter. |
+| 3 | **Hacker News** | _none required_ | ⚠️ picsum placeholder | Public Firebase API. Default fallback. |
+
+## 📚 Additional Resources
+
+- **Element-Tree Primitives**: [https://docs.agentverse.ai/documentation/advanced-usages/element-tree-primitives](https://docs.agentverse.ai/documentation/advanced-usages/element-tree-primitives)
+- **Predefined Card Schemas**: [https://docs.agentverse.ai/documentation/advanced-usages/predefined-card-schemas](https://docs.agentverse.ai/documentation/advanced-usages/predefined-card-schemas)
+- **Agent-Driven Interactive Cards**: [https://docs.agentverse.ai/documentation/advanced-usages/agent-driven-interactive-cards](https://docs.agentverse.ai/documentation/advanced-usages/agent-driven-interactive-cards)
+- **Card Playground**: [https://asi1.ai/developer/card-playground](https://asi1.ai/developer/card-playground)
+- **Tavily API**: [https://docs.tavily.com](https://docs.tavily.com)
+- **NewsAPI.org**: [https://newsapi.org/docs](https://newsapi.org/docs)
+- **ASI1 One LLM**: [https://asi1.ai](https://asi1.ai)
+
+## 🧠 Inspired by
+
+* [Fetch.ai uAgents](https://github.com/fetchai/uAgents)
+* [Agentverse Interactive Cards](https://docs.agentverse.ai/documentation/advanced-usages/agent-driven-interactive-cards)
+* [ASI1 One LLM](https://asi1.ai)
+* [Tavily Search API](https://app.tavily.com/home)
+* [Fetch.ai Innovation Lab Examples](https://github.com/fetchai/innovation-lab-examples)

--- a/news-card-agent/agent.py
+++ b/news-card-agent/agent.py
@@ -27,7 +27,12 @@ async def startup(ctx: Context):
     ctx.logger.info("=== News Card Agent ===")
     ctx.logger.info(f"News backend: {active_backend()}")
     ctx.logger.info(
-        "ASI1 LLM: " + ("enabled" if (os.getenv("ASI_ONE_API_KEY") or os.getenv("ASI1_API_KEY")) else "disabled (fallback summaries)")
+        "ASI1 LLM: "
+        + (
+            "enabled"
+            if (os.getenv("ASI_ONE_API_KEY") or os.getenv("ASI1_API_KEY"))
+            else "disabled (fallback summaries)"
+        )
     )
     ctx.logger.info("Chat with the agent to receive a news card.")
 

--- a/news-card-agent/agent.py
+++ b/news-card-agent/agent.py
@@ -1,0 +1,36 @@
+"""News-card agent entrypoint (no payment protocol)."""
+
+import os
+
+from dotenv import load_dotenv
+from uagents import Agent, Context
+
+load_dotenv()
+
+from chat_proto import chat_proto  # noqa: E402  (load env before importing)
+from news_client import active_backend  # noqa: E402
+
+
+agent = Agent(
+    name=os.getenv("AGENT_NAME", "News Card Agent"),
+    seed=os.getenv("AGENT_SEED_PHRASE", "news-card-agent-seed"),
+    port=int(os.getenv("AGENT_PORT", "8000")),
+    mailbox=True,
+)
+
+agent.include(chat_proto, publish_manifest=True)
+
+
+@agent.on_event("startup")
+async def startup(ctx: Context):
+    ctx.logger.info(f"Agent started: {agent.address}")
+    ctx.logger.info("=== News Card Agent ===")
+    ctx.logger.info(f"News backend: {active_backend()}")
+    ctx.logger.info(
+        "ASI1 LLM: " + ("enabled" if (os.getenv("ASI_ONE_API_KEY") or os.getenv("ASI1_API_KEY")) else "disabled (fallback summaries)")
+    )
+    ctx.logger.info("Chat with the agent to receive a news card.")
+
+
+if __name__ == "__main__":
+    agent.run()

--- a/news-card-agent/asi1_client.py
+++ b/news-card-agent/asi1_client.py
@@ -22,15 +22,15 @@ from dotenv import load_dotenv
 load_dotenv()
 
 ASI_ONE_API_KEY = (
-    os.getenv("ASI_ONE_API_KEY")
-    or os.getenv("ASI1_API_KEY")
-    or ""
+    os.getenv("ASI_ONE_API_KEY") or os.getenv("ASI1_API_KEY") or ""
 ).strip()
 ASI_ONE_MODEL = os.getenv("ASI_ONE_MODEL", "asi1")
 ASI_ONE_CHAT_URL = "https://api.asi1.ai/v1/chat/completions"
 
 
-def _chat_completion(messages: list[dict[str, str]], *, max_tokens: int = 200) -> str | None:
+def _chat_completion(
+    messages: list[dict[str, str]], *, max_tokens: int = 200
+) -> str | None:
     """Synchronous helper that performs a single chat-completion call."""
     if not ASI_ONE_API_KEY:
         return None
@@ -48,7 +48,9 @@ def _chat_completion(messages: list[dict[str, str]], *, max_tokens: int = 200) -
     }
 
     try:
-        resp = requests.post(ASI_ONE_CHAT_URL, json=payload, headers=headers, timeout=45)
+        resp = requests.post(
+            ASI_ONE_CHAT_URL, json=payload, headers=headers, timeout=45
+        )
         if not resp.ok:
             return None
         data = resp.json()
@@ -68,7 +70,11 @@ async def summarise_article(*, title: str, description: str) -> str:
     Falls back to the raw description (truncated) when ASI1 is unavailable.
     """
     raw = (description or "").strip()
-    fallback = raw[:200] + ("…" if len(raw) > 200 else "") if raw else "Tap to read the full article."
+    fallback = (
+        raw[:200] + ("…" if len(raw) > 200 else "")
+        if raw
+        else "Tap to read the full article."
+    )
 
     if not ASI_ONE_API_KEY:
         return fallback

--- a/news-card-agent/asi1_client.py
+++ b/news-card-agent/asi1_client.py
@@ -1,0 +1,156 @@
+"""ASI1 One LLM chat-completion client.
+
+Used for two light-weight tasks:
+
+- Polishing a raw news article description into a one-sentence card subtitle.
+- Generating a friendly natural-language preamble when sending the news card.
+
+The agent will degrade gracefully (return the input unchanged) if the API key
+is missing or the request fails — the cards are still rendered, just without
+LLM polish.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+ASI_ONE_API_KEY = (
+    os.getenv("ASI_ONE_API_KEY")
+    or os.getenv("ASI1_API_KEY")
+    or ""
+).strip()
+ASI_ONE_MODEL = os.getenv("ASI_ONE_MODEL", "asi1")
+ASI_ONE_CHAT_URL = "https://api.asi1.ai/v1/chat/completions"
+
+
+def _chat_completion(messages: list[dict[str, str]], *, max_tokens: int = 200) -> str | None:
+    """Synchronous helper that performs a single chat-completion call."""
+    if not ASI_ONE_API_KEY:
+        return None
+
+    headers = {
+        "Authorization": f"Bearer {ASI_ONE_API_KEY}",
+        "Content-Type": "application/json",
+    }
+    payload: dict[str, Any] = {
+        "model": ASI_ONE_MODEL,
+        "messages": messages,
+        "temperature": 0.4,
+        "max_tokens": max_tokens,
+        "stream": False,
+    }
+
+    try:
+        resp = requests.post(ASI_ONE_CHAT_URL, json=payload, headers=headers, timeout=45)
+        if not resp.ok:
+            return None
+        data = resp.json()
+        choices = data.get("choices") or []
+        if not choices:
+            return None
+        return (choices[0].get("message") or {}).get("content")
+    except requests.RequestException:
+        return None
+    except Exception:
+        return None
+
+
+async def summarise_article(*, title: str, description: str) -> str:
+    """Return a polished one-sentence subtitle for a news card.
+
+    Falls back to the raw description (truncated) when ASI1 is unavailable.
+    """
+    raw = (description or "").strip()
+    fallback = raw[:200] + ("…" if len(raw) > 200 else "") if raw else "Tap to read the full article."
+
+    if not ASI_ONE_API_KEY:
+        return fallback
+
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "You write ultra-concise news card subtitles for a mobile UI. "
+                "Reply with exactly one sentence, no quotes, no emojis, under 25 words."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"Headline: {title}\n"
+                f"Raw description: {raw or '(none)'}\n\n"
+                "Write the one-sentence card subtitle."
+            ),
+        },
+    ]
+
+    result = await asyncio.to_thread(_chat_completion, messages, max_tokens=80)
+    if not result:
+        return fallback
+
+    cleaned = result.strip().strip('"').strip()
+    return cleaned or fallback
+
+
+async def craft_preamble(*, user_query: str, count: int, backend: str) -> str:
+    """Short friendly intro line before the news card. Has a sensible fallback."""
+    fallback = f"Here are {count} of the latest stories from {backend}."
+
+    if not ASI_ONE_API_KEY:
+        return fallback
+
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "You are the assistant intro line for a news card. "
+                "Reply with a single short sentence (<20 words), no emojis, no markdown."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"The user asked: '{user_query or 'latest news'}'. "
+                f"You are about to show {count} articles from {backend}. "
+                "Write the intro line."
+            ),
+        },
+    ]
+
+    result = await asyncio.to_thread(_chat_completion, messages, max_tokens=60)
+    if not result:
+        return fallback
+    return result.strip().strip('"').strip() or fallback
+
+
+async def craft_article_preamble(*, title: str) -> str:
+    """Short intro line shown above the article detail card."""
+    fallback = "Here is the full article."
+
+    if not ASI_ONE_API_KEY:
+        return fallback
+
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "You write a single short intro sentence (<15 words) shown above "
+                "an article detail card. No emojis, no markdown."
+            ),
+        },
+        {
+            "role": "user",
+            "content": f"Article title: {title}\nWrite the intro line.",
+        },
+    ]
+    result = await asyncio.to_thread(_chat_completion, messages, max_tokens=40)
+    if not result:
+        return fallback
+    return result.strip().strip('"').strip() or fallback

--- a/news-card-agent/cards.py
+++ b/news-card-agent/cards.py
@@ -1,0 +1,228 @@
+"""Card builders using Agentverse element-tree primitives.
+
+Two card kinds are produced:
+
+1. News list card - a `section` containing a `list` of news items. Each item
+   has an image, a title/description group, and a "Read Full Article" button
+   whose `action.selection` carries the `article_id`.
+2. Article detail card - rendered when the user taps "Read Full Article".
+
+The agent sends each card as a `MetadataContent` block on the chat protocol,
+following:
+https://docs.agentverse.ai/documentation/advanced-usages/agent-driven-interactive-cards
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from uagents_core.contrib.protocols.chat import (
+    ChatMessage,
+    MetadataContent,
+    TextContent,
+)
+
+from news_client import Article
+
+
+CARD_PROTOCOL_VERSION = "1"
+NEWS_TAB_SOURCE = "news_tab"
+
+
+def build_news_list_payload(
+    articles: list[Article],
+    *,
+    title: str = "Latest News",
+    subtitle: str | None = "Tap an article to read more",
+    summaries: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Build the `card_payload` dict for the news list card.
+
+    `summaries` optionally overrides each article's subtitle text (keyed by
+    `article_id`); defaults to the article's raw description.
+    """
+    summaries = summaries or {}
+    items: list[dict[str, Any]] = []
+
+    for article in articles:
+        subtitle_text = summaries.get(article.article_id) or article.description
+        items.append(
+            {
+                "children": [
+                    {
+                        "type": "image",
+                        "src": article.image_url,
+                        "alt": f"Image for {article.title}",
+                        "aspect_ratio": "16:9",
+                    },
+                    {
+                        "type": "group",
+                        "direction": "column",
+                        "gap": 8,
+                        "children": [
+                            {
+                                "type": "heading",
+                                "value": article.title,
+                                "level": 3,
+                            },
+                            {
+                                "type": "text",
+                                "value": subtitle_text,
+                                "style": "body",
+                            },
+                            {
+                                "type": "badge",
+                                "label": article.source,
+                                "variant": "info",
+                            },
+                        ],
+                    },
+                    {
+                        "type": "button",
+                        "label": "Read Full Article",
+                        "primary": True,
+                        "action": {
+                            "selection": {
+                                "article_id": article.article_id,
+                                "source": NEWS_TAB_SOURCE,
+                            }
+                        },
+                    },
+                ]
+            }
+        )
+
+    section: dict[str, Any] = {
+        "type": "section",
+        "title": title,
+        "children": [
+            {
+                "type": "list",
+                "items": items,
+            }
+        ],
+    }
+    if subtitle:
+        section["subtitle"] = subtitle
+
+    return {"root": section}
+
+
+def build_article_detail_payload(article: Article) -> dict[str, Any]:
+    """Build the `card_payload` dict for the article detail card."""
+    section: dict[str, Any] = {
+        "type": "section",
+        "title": article.title,
+        "children": [
+            {
+                "type": "image",
+                "src": article.image_url,
+                "alt": f"Hero image for {article.title}",
+                "aspect_ratio": "16:9",
+            },
+            {
+                "type": "group",
+                "direction": "column",
+                "gap": 12,
+                "children": [
+                    {
+                        "type": "badge",
+                        "label": article.source,
+                        "variant": "info",
+                    },
+                    {
+                        "type": "heading",
+                        "value": article.title,
+                        "level": 2,
+                    },
+                    {
+                        "type": "text",
+                        "value": article.description or "Tap the source link below to read the full article.",
+                        "style": "body",
+                    },
+                    {"type": "divider"},
+                    {
+                        "type": "text",
+                        "value": f"Source: {article.url}",
+                        "style": "muted",
+                    },
+                ],
+            },
+            {
+                "type": "group",
+                "direction": "row",
+                "gap": 8,
+                "children": [
+                    {
+                        "type": "button",
+                        "label": "Back to News",
+                        "primary": False,
+                        "action": {
+                            "selection": {
+                                "action": "back_to_news",
+                                "source": NEWS_TAB_SOURCE,
+                            }
+                        },
+                    },
+                ],
+            },
+        ],
+    }
+    return {"root": section}
+
+
+def _card_metadata(card_payload: dict[str, Any]) -> MetadataContent:
+    """Wrap a payload dict into a MetadataContent block for ChatMessage."""
+    return MetadataContent(
+        type="metadata",
+        metadata={
+            "card_protocol_version": CARD_PROTOCOL_VERSION,
+            "requires_card_interaction": "true",
+            "card_kind": "custom",
+            "card_payload": json.dumps(card_payload),
+        },
+    )
+
+
+def build_news_list_message(
+    *,
+    preamble: str,
+    articles: list[Article],
+    summaries: dict[str, str] | None = None,
+    title: str = "Latest News",
+) -> ChatMessage:
+    """Create a ChatMessage carrying the news list card + an intro text bubble."""
+    payload = build_news_list_payload(articles, title=title, summaries=summaries)
+    return ChatMessage(
+        timestamp=datetime.now(timezone.utc),
+        msg_id=uuid4(),
+        content=[
+            TextContent(type="text", text=preamble),
+            _card_metadata(payload),
+        ],
+    )
+
+
+def build_article_detail_message(
+    *,
+    preamble: str,
+    article: Article,
+) -> ChatMessage:
+    """Create a ChatMessage carrying the article detail card.
+
+    The article URL is also included as a markdown link inside the text bubble
+    so that users can open the source in a new tab directly from chat.
+    """
+    payload = build_article_detail_payload(article)
+    text = f"{preamble}\n\n[Open original article]({article.url})"
+    return ChatMessage(
+        timestamp=datetime.now(timezone.utc),
+        msg_id=uuid4(),
+        content=[
+            TextContent(type="text", text=text),
+            _card_metadata(payload),
+        ],
+    )

--- a/news-card-agent/cards.py
+++ b/news-card-agent/cards.py
@@ -140,7 +140,8 @@ def build_article_detail_payload(article: Article) -> dict[str, Any]:
                     },
                     {
                         "type": "text",
-                        "value": article.description or "Tap the source link below to read the full article.",
+                        "value": article.description
+                        or "Tap the source link below to read the full article.",
                         "style": "body",
                     },
                     {"type": "divider"},

--- a/news-card-agent/chat_proto.py
+++ b/news-card-agent/chat_proto.py
@@ -56,7 +56,9 @@ ARTICLE_KEY_PREFIX = "news:article:"
 def _store_articles(ctx: Context, articles: list[Article]) -> None:
     """Persist articles in storage so we can look them up on card click."""
     for article in articles:
-        ctx.storage.set(ARTICLE_KEY_PREFIX + article.article_id, json.dumps(article.to_dict()))
+        ctx.storage.set(
+            ARTICLE_KEY_PREFIX + article.article_id, json.dumps(article.to_dict())
+        )
 
 
 def _load_article(ctx: Context, article_id: str) -> Article | None:
@@ -80,11 +82,16 @@ async def _send_news_card(ctx: Context, sender: str, query: str) -> None:
         articles = await fetch_news(query=query)
     except Exception as exc:
         ctx.logger.exception("News fetch failed")
-        await ctx.send(sender, create_text_chat(f"Sorry, I couldn't fetch the news right now: {exc}"))
+        await ctx.send(
+            sender,
+            create_text_chat(f"Sorry, I couldn't fetch the news right now: {exc}"),
+        )
         return
 
     if not articles:
-        await ctx.send(sender, create_text_chat("No news articles found. Try a different topic?"))
+        await ctx.send(
+            sender, create_text_chat("No news articles found. Try a different topic?")
+        )
         return
 
     _store_articles(ctx, articles)
@@ -100,14 +107,17 @@ async def _send_news_card(ctx: Context, sender: str, query: str) -> None:
     preamble, *summaries_list = await asyncio.gather(preamble_task, *summary_tasks)
 
     summaries = {
-        article.article_id: summary for article, summary in zip(articles, summaries_list)
+        article.article_id: summary
+        for article, summary in zip(articles, summaries_list)
     }
 
     message = build_news_list_message(
         preamble=preamble,
         articles=articles,
         summaries=summaries,
-        title="Latest News" if not query or query.lower() in {"latest", "news"} else f"News · {query.title()}",
+        title="Latest News"
+        if not query or query.lower() in {"latest", "news"}
+        else f"News · {query.title()}",
     )
     await ctx.send(sender, message)
     ctx.logger.info(f"Sent news card with {len(articles)} articles to {sender}")

--- a/news-card-agent/chat_proto.py
+++ b/news-card-agent/chat_proto.py
@@ -1,0 +1,187 @@
+"""Chat protocol handlers for the news-card agent.
+
+Flow:
+
+1. User sends any text (e.g. "show me tech news") → the agent fetches news,
+   caches each article in storage by `article_id`, polishes subtitles with
+   ASI1, and replies with a `custom` card containing a list of articles plus
+   "Read Full Article" buttons.
+
+2. User taps a button → the chat UI forwards a follow-up `ChatMessage` whose
+   `TextContent` is the selection (JSON for direct @mention, prose via the
+   planner). We parse it, look the article up in storage, and reply with a
+   new article detail card.
+
+3. The detail card also has a "Back to News" button which re-runs step 1.
+
+There is intentionally no payment protocol on this agent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+
+from uagents import Context, Protocol
+from uagents_core.contrib.protocols.chat import (
+    ChatAcknowledgement,
+    ChatMessage,
+    MetadataContent,
+    StartSessionContent,
+    TextContent,
+    chat_protocol_spec,
+)
+
+from asi1_client import (
+    craft_article_preamble,
+    craft_preamble,
+    summarise_article,
+)
+from cards import (
+    build_article_detail_message,
+    build_news_list_message,
+)
+from news_client import Article, active_backend, fetch_news
+from shared import create_text_chat, parse_card_selection
+
+
+chat_proto = Protocol(spec=chat_protocol_spec)
+
+
+LAST_QUERY_KEY = "news:last_query"
+ARTICLE_KEY_PREFIX = "news:article:"
+
+
+def _store_articles(ctx: Context, articles: list[Article]) -> None:
+    """Persist articles in storage so we can look them up on card click."""
+    for article in articles:
+        ctx.storage.set(ARTICLE_KEY_PREFIX + article.article_id, json.dumps(article.to_dict()))
+
+
+def _load_article(ctx: Context, article_id: str) -> Article | None:
+    raw = ctx.storage.get(ARTICLE_KEY_PREFIX + article_id)
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    try:
+        return Article.from_dict(data)
+    except TypeError:
+        return None
+
+
+async def _send_news_card(ctx: Context, sender: str, query: str) -> None:
+    """Fetch news, polish, store, and send the news list card."""
+    ctx.logger.info(f"Fetching news for query='{query}' via {active_backend()}")
+    try:
+        articles = await fetch_news(query=query)
+    except Exception as exc:
+        ctx.logger.exception("News fetch failed")
+        await ctx.send(sender, create_text_chat(f"Sorry, I couldn't fetch the news right now: {exc}"))
+        return
+
+    if not articles:
+        await ctx.send(sender, create_text_chat("No news articles found. Try a different topic?"))
+        return
+
+    _store_articles(ctx, articles)
+    ctx.storage.set(LAST_QUERY_KEY, query)
+
+    # Summarise + craft preamble concurrently.
+    preamble_task = craft_preamble(
+        user_query=query, count=len(articles), backend=active_backend()
+    )
+    summary_tasks = [
+        summarise_article(title=a.title, description=a.description) for a in articles
+    ]
+    preamble, *summaries_list = await asyncio.gather(preamble_task, *summary_tasks)
+
+    summaries = {
+        article.article_id: summary for article, summary in zip(articles, summaries_list)
+    }
+
+    message = build_news_list_message(
+        preamble=preamble,
+        articles=articles,
+        summaries=summaries,
+        title="Latest News" if not query or query.lower() in {"latest", "news"} else f"News · {query.title()}",
+    )
+    await ctx.send(sender, message)
+    ctx.logger.info(f"Sent news card with {len(articles)} articles to {sender}")
+
+
+async def _send_article_detail(ctx: Context, sender: str, article_id: str) -> None:
+    """Look up an article and send the detail card."""
+    article = _load_article(ctx, article_id)
+    if not article:
+        ctx.logger.warning(f"Article {article_id} not found in storage")
+        await ctx.send(
+            sender,
+            create_text_chat(
+                "I couldn't find that article anymore. Ask me for the latest news again."
+            ),
+        )
+        return
+
+    preamble = await craft_article_preamble(title=article.title)
+    message = build_article_detail_message(preamble=preamble, article=article)
+    await ctx.send(sender, message)
+    ctx.logger.info(f"Sent detail card for article {article_id} to {sender}")
+
+
+@chat_proto.on_message(ChatMessage)
+async def handle_message(ctx: Context, sender: str, msg: ChatMessage):
+    ctx.logger.info(f"Got a message from {sender}")
+
+    await ctx.send(
+        sender,
+        ChatAcknowledgement(
+            timestamp=datetime.now(timezone.utc),
+            acknowledged_msg_id=msg.msg_id,
+        ),
+    )
+
+    # Greet on session start with a hint, and let the UI know we expect a query.
+    if any(isinstance(c, StartSessionContent) for c in msg.content):
+        await ctx.send(
+            sender,
+            create_text_chat(
+                "Hi! Ask me for the latest news (try 'latest tech news', "
+                "'world news', or just 'news')."
+            ),
+        )
+        return
+
+    for item in msg.content:
+        if isinstance(item, TextContent):
+            text = (item.text or "").strip()
+            if not text:
+                continue
+
+            selection = parse_card_selection(text)
+            if selection:
+                ctx.logger.info(f"Parsed card selection: {selection}")
+                if selection.get("action") == "back_to_news":
+                    previous_query = ctx.storage.get(LAST_QUERY_KEY) or "latest"
+                    await _send_news_card(ctx, sender, previous_query)
+                    return
+                article_id = selection.get("article_id")
+                if article_id:
+                    await _send_article_detail(ctx, sender, article_id)
+                    return
+
+            await _send_news_card(ctx, sender, text)
+            return
+
+        if isinstance(item, MetadataContent):
+            ctx.logger.debug(f"Received metadata: {item.metadata}")
+
+
+@chat_proto.on_message(ChatAcknowledgement)
+async def handle_ack(ctx: Context, sender: str, msg: ChatAcknowledgement):
+    ctx.logger.info(
+        f"Got an acknowledgement from {sender} for {msg.acknowledged_msg_id}"
+    )

--- a/news-card-agent/news_client.py
+++ b/news-card-agent/news_client.py
@@ -132,7 +132,9 @@ def _fetch_tavily(query: str | None, limit: int) -> list[Article]:
             continue
 
         article_id = "tv_" + _short_id(url)
-        image_url = image_urls[idx] if idx < len(image_urls) else _placeholder_image(article_id)
+        image_url = (
+            image_urls[idx] if idx < len(image_urls) else _placeholder_image(article_id)
+        )
         image_url = _force_https(image_url)
 
         content = (item.get("content") or item.get("raw_content") or "").strip()
@@ -187,7 +189,9 @@ def _detect_category(query: str | None) -> str | None:
     return None
 
 
-def _fetch_newsapi(query: str | None, category: str | None, limit: int) -> list[Article]:
+def _fetch_newsapi(
+    query: str | None, category: str | None, limit: int
+) -> list[Article]:
     """Fetch articles from NewsAPI.org. Requires NEWS_API_KEY."""
     params: dict[str, Any] = {
         "pageSize": min(limit, 20),
@@ -229,7 +233,9 @@ def _fetch_newsapi(query: str | None, category: str | None, limit: int) -> list[
             continue
 
         article_id = "na_" + _short_id(url_field)
-        image_url = _force_https(raw.get("urlToImage") or _placeholder_image(article_id))
+        image_url = _force_https(
+            raw.get("urlToImage") or _placeholder_image(article_id)
+        )
 
         description = (raw.get("description") or raw.get("content") or "").strip()
         if not description:

--- a/news-card-agent/news_client.py
+++ b/news-card-agent/news_client.py
@@ -1,0 +1,338 @@
+"""News API client.
+
+Backends (in priority order, first one with a key wins):
+
+1. **Tavily** (`TAVILY_API_KEY`) — web search with a `topic: "news"` mode.
+   Returns titles, snippets and image URLs from across the web.
+2. **NewsAPI.org** (`NEWS_API_KEY`) — top-headlines or /everything search.
+3. **Hacker News** — public Firebase API, no key required. Default fallback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+from dataclasses import asdict, dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+TAVILY_API_KEY = os.getenv("TAVILY_API_KEY", "").strip()
+TAVILY_SEARCH_URL = "https://api.tavily.com/search"
+
+NEWS_API_KEY = os.getenv("NEWS_API_KEY", "").strip()
+NEWS_API_TOP_URL = "https://newsapi.org/v2/top-headlines"
+NEWS_API_EVERYTHING_URL = "https://newsapi.org/v2/everything"
+
+HN_TOP_URL = "https://hacker-news.firebaseio.com/v0/topstories.json"
+HN_ITEM_URL = "https://hacker-news.firebaseio.com/v0/item/{id}.json"
+
+DEFAULT_LIMIT = 6
+
+# Country values that mean "no country filter".
+_ANY_COUNTRY = {"", "any", "all", "global", "world"}
+
+
+@dataclass
+class Article:
+    """Normalised article shape consumed by the card builder."""
+
+    article_id: str
+    title: str
+    description: str
+    url: str
+    image_url: str
+    source: str
+    published_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Article":
+        return cls(**data)
+
+
+def _placeholder_image(seed: str) -> str:
+    """Deterministic picsum.photos image URL for a given seed string."""
+    digest = hashlib.md5(seed.encode("utf-8")).hexdigest()[:10]
+    return f"https://picsum.photos/seed/{digest}/800/450"
+
+
+def _short_id(value: str) -> str:
+    return hashlib.md5(value.encode("utf-8")).hexdigest()[:12]
+
+
+def _force_https(url: str) -> str:
+    if url.startswith("http://"):
+        return "https://" + url[len("http://") :]
+    return url
+
+
+def _country_param() -> str | None:
+    """Return the NEWS_API_COUNTRY env value, or None when set to 'any'."""
+    raw = os.getenv("NEWS_API_COUNTRY", "").strip().lower()
+    if raw in _ANY_COUNTRY:
+        return None
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Tavily backend
+# ---------------------------------------------------------------------------
+
+
+def _fetch_tavily(query: str | None, limit: int) -> list[Article]:
+    """Fetch news-topic search results from Tavily.
+
+    Tavily returns `results` (article-like records) and a parallel `images`
+    array. We pair them by index and fall back to a picsum placeholder when
+    no image is available.
+    """
+    search_query = (query or "").strip() or "latest breaking news today"
+    payload: dict[str, Any] = {
+        "api_key": TAVILY_API_KEY,
+        "query": search_query,
+        "topic": "news",
+        "max_results": max(limit, 1),
+        "search_depth": "basic",
+        "include_images": True,
+        "include_answer": False,
+    }
+    headers = {"Content-Type": "application/json"}
+
+    resp = requests.post(TAVILY_SEARCH_URL, json=payload, headers=headers, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+
+    raw_results = data.get("results") or []
+    raw_images = data.get("images") or []
+
+    # Normalise the image list — Tavily returns either a list of URL strings
+    # or a list of {"url": ..., "description": ...} dicts depending on flags.
+    image_urls: list[str] = []
+    for img in raw_images:
+        if isinstance(img, str):
+            image_urls.append(img)
+        elif isinstance(img, dict):
+            url = img.get("url")
+            if isinstance(url, str):
+                image_urls.append(url)
+
+    articles: list[Article] = []
+    for idx, item in enumerate(raw_results[:limit]):
+        title = (item.get("title") or "").strip()
+        url = (item.get("url") or "").strip()
+        if not title or not url:
+            continue
+
+        article_id = "tv_" + _short_id(url)
+        image_url = image_urls[idx] if idx < len(image_urls) else _placeholder_image(article_id)
+        image_url = _force_https(image_url)
+
+        content = (item.get("content") or item.get("raw_content") or "").strip()
+        if not content:
+            content = "Tap to read the full article."
+        if len(content) > 600:
+            content = content[:600].rstrip() + "…"
+
+        netloc = urlparse(url).netloc or "Web"
+        source = netloc.removeprefix("www.")
+
+        articles.append(
+            Article(
+                article_id=article_id,
+                title=title,
+                description=content,
+                url=url,
+                image_url=image_url,
+                source=source,
+                published_at=str(item.get("published_date") or ""),
+            )
+        )
+    return articles
+
+
+# ---------------------------------------------------------------------------
+# NewsAPI.org backend
+# ---------------------------------------------------------------------------
+
+
+def _detect_category(query: str | None) -> str | None:
+    """Map a free-text query to a NewsAPI category if possible."""
+    if not query:
+        return None
+    q = query.lower()
+    mapping = {
+        "tech": "technology",
+        "technology": "technology",
+        "business": "business",
+        "sports": "sports",
+        "sport": "sports",
+        "entertainment": "entertainment",
+        "health": "health",
+        "science": "science",
+        "general": "general",
+        "world": "general",
+        "latest": None,
+    }
+    for key, value in mapping.items():
+        if key in q:
+            return value
+    return None
+
+
+def _fetch_newsapi(query: str | None, category: str | None, limit: int) -> list[Article]:
+    """Fetch articles from NewsAPI.org. Requires NEWS_API_KEY."""
+    params: dict[str, Any] = {
+        "pageSize": min(limit, 20),
+        "apiKey": NEWS_API_KEY,
+        "language": "en",
+    }
+
+    country = _country_param()
+    generic_query = (query or "").strip().lower() in {"", "latest", "news", "top"}
+
+    if query and not generic_query:
+        # Specific user search → /everything.
+        params["q"] = query
+        params["sortBy"] = "publishedAt"
+        url = NEWS_API_EVERYTHING_URL
+    elif country or category:
+        # Generic ask + a country/category filter → /top-headlines.
+        url = NEWS_API_TOP_URL
+        if country:
+            params["country"] = country
+        if category:
+            params["category"] = category
+    else:
+        # No constraints → fall back to /everything with a generic query.
+        url = NEWS_API_EVERYTHING_URL
+        params["q"] = "news"
+        params["sortBy"] = "publishedAt"
+
+    resp = requests.get(url, params=params, timeout=25)
+    resp.raise_for_status()
+    payload = resp.json()
+
+    raw_articles = payload.get("articles", []) or []
+    articles: list[Article] = []
+    for raw in raw_articles[:limit]:
+        title = raw.get("title")
+        url_field = raw.get("url")
+        if not title or not url_field:
+            continue
+
+        article_id = "na_" + _short_id(url_field)
+        image_url = _force_https(raw.get("urlToImage") or _placeholder_image(article_id))
+
+        description = (raw.get("description") or raw.get("content") or "").strip()
+        if not description:
+            description = "Tap to read the full article."
+
+        articles.append(
+            Article(
+                article_id=article_id,
+                title=title.strip(),
+                description=description,
+                url=url_field,
+                image_url=image_url,
+                source=((raw.get("source") or {}).get("name") or "News").strip(),
+                published_at=raw.get("publishedAt", ""),
+            )
+        )
+    return articles
+
+
+# ---------------------------------------------------------------------------
+# Hacker News backend (no key required)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_hackernews(limit: int) -> list[Article]:
+    """Fetch top stories from the public Hacker News API (no key required)."""
+    resp = requests.get(HN_TOP_URL, timeout=20)
+    resp.raise_for_status()
+    ids: list[int] = resp.json()[: max(limit * 2, limit)]
+
+    articles: list[Article] = []
+    for story_id in ids:
+        if len(articles) >= limit:
+            break
+        try:
+            item_resp = requests.get(HN_ITEM_URL.format(id=story_id), timeout=15)
+            item_resp.raise_for_status()
+            item = item_resp.json() or {}
+        except requests.RequestException:
+            continue
+
+        title = item.get("title")
+        url = item.get("url") or f"https://news.ycombinator.com/item?id={story_id}"
+        if not title:
+            continue
+
+        score = item.get("score", 0)
+        by = item.get("by", "anonymous")
+        descendants = item.get("descendants", 0)
+        description = (
+            f"Posted by {by} · {score} points · {descendants} comments on Hacker News."
+        )
+
+        articles.append(
+            Article(
+                article_id=f"hn_{story_id}",
+                title=title,
+                description=description,
+                url=url,
+                image_url=_placeholder_image(f"hn-{story_id}-{title}"),
+                source="Hacker News",
+                published_at=str(item.get("time", "")),
+            )
+        )
+    return articles
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def active_backend() -> str:
+    """Human-readable label for the active news backend."""
+    if TAVILY_API_KEY:
+        return "Tavily"
+    if NEWS_API_KEY:
+        return "NewsAPI.org"
+    return "Hacker News"
+
+
+async def fetch_news(
+    *,
+    query: str | None = None,
+    limit: int = DEFAULT_LIMIT,
+) -> list[Article]:
+    """Fetch a list of articles.
+
+    Picks the highest-priority configured backend (Tavily → NewsAPI → Hacker
+    News) and runs the blocking HTTP call in a worker thread. `query` is a
+    free-text user query: it becomes the search term for Tavily/NewsAPI and
+    is ignored by Hacker News (which always returns top stories).
+    """
+
+    def _work() -> list[Article]:
+        try:
+            if TAVILY_API_KEY:
+                return _fetch_tavily(query=query, limit=limit)
+            if NEWS_API_KEY:
+                category = _detect_category(query)
+                return _fetch_newsapi(query=query, category=category, limit=limit)
+            return _fetch_hackernews(limit=limit)
+        except requests.RequestException as exc:
+            raise RuntimeError(f"News API request failed: {exc}") from exc
+
+    return await asyncio.to_thread(_work)

--- a/news-card-agent/requirements.txt
+++ b/news-card-agent/requirements.txt
@@ -1,0 +1,4 @@
+uagents==0.23.6
+uagents-core==0.4.0
+python-dotenv
+requests

--- a/news-card-agent/shared.py
+++ b/news-card-agent/shared.py
@@ -1,0 +1,76 @@
+"""Small shared helpers (kept minimal to avoid circular imports)."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from uagents_core.contrib.protocols.chat import (
+    AgentContent,
+    ChatMessage,
+    EndSessionContent,
+    TextContent,
+)
+
+
+def create_text_chat(text: str, *, end_session: bool = False) -> ChatMessage:
+    """Build a simple text-only ChatMessage (optionally closing the session)."""
+    content: list[AgentContent] = [TextContent(type="text", text=text)]
+    if end_session:
+        content.append(EndSessionContent(type="end-session"))
+    return ChatMessage(
+        timestamp=datetime.now(timezone.utc),
+        msg_id=uuid4(),
+        content=content,
+    )
+
+
+_ARTICLE_ID_PROSE_RE = re.compile(
+    r"article[_\s-]?id[\s:=\"']*([A-Za-z0-9_\-]+)", re.IGNORECASE
+)
+_BACK_TO_NEWS_RE = re.compile(r"back[_\s-]?to[_\s-]?news", re.IGNORECASE)
+
+
+def parse_card_selection(text: str) -> dict[str, str] | None:
+    """Extract a card-selection dict from inbound text.
+
+    The chat UI delivers selections in one of two shapes:
+
+    - Direct @mention: a JSON object serialized as text, e.g.
+      `{"article_id": "hn_42", "source": "news_tab"}`.
+    - Via the planner: free prose mentioning the selection fields, e.g.
+      `"The user picked article_id hn_42 from news_tab."`.
+
+    Returns a dict with at least one of `article_id` or `action` keys, or
+    `None` if the text doesn't look like a card selection.
+    """
+    if not text:
+        return None
+
+    stripped = text.strip()
+
+    if stripped.startswith("{") and stripped.endswith("}"):
+        try:
+            data = json.loads(stripped)
+        except json.JSONDecodeError:
+            data = None
+        if isinstance(data, dict):
+            result: dict[str, str] = {}
+            for key in ("article_id", "action", "source"):
+                value = data.get(key)
+                if isinstance(value, str):
+                    result[key] = value
+            if result:
+                return result
+
+    selection: dict[str, str] = {}
+    if _BACK_TO_NEWS_RE.search(stripped):
+        selection["action"] = "back_to_news"
+
+    match = _ARTICLE_ID_PROSE_RE.search(stripped)
+    if match:
+        selection["article_id"] = match.group(1)
+
+    return selection or None


### PR DESCRIPTION
## Summary

Adds a new official example, `news-card-agent/`, that demonstrates **agent-driven interactive cards** on ASI:One without any payment protocol.

- Live news is rendered as a `card_kind: "custom"` element-tree (`section` → `list` of items with image, heading, text, source badge, and a primary **Read Full Article** button).
- Tapping a button triggers a follow-up `ChatMessage` whose `TextContent` is the button's `selection` payload. The agent parses it (handling both raw JSON for direct `@mention` and natural-language prose from the planner), looks up the cached article in `ctx.storage`, and renders a brand-new **article detail card** plus a clickable markdown link to the source. A **Back to News** button on the detail card re-renders the list for the last query.
- Multi-backend news cascade picks the highest-priority configured source: **Tavily** (`topic: "news"` web search, default) → **NewsAPI.org** (`/top-headlines` or `/everything` with `NEWS_API_COUNTRY=any` support) → **Hacker News** Firebase API (no key required, used as zero-config fallback).
- **ASI1 One LLM** (`asi1-mini` via `https://api.asi1.ai/v1/chat/completions`) polishes each article subtitle into a single tight sentence and writes the intro line above the card. All three LLM helpers degrade gracefully when no API key is set.
- Project structure mirrors `fet-example/`: `agent.py`, `chat_proto.py`, `cards.py` (element-tree builders), `news_client.py`, `asi1_client.py`, `shared.py`, `requirements.txt`, `.env.example`, and a comprehensive `README.md`.

## Type of Change

- [x] New agent example
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other

## Checklist

- [x] I have starred this repository.
- [x] **New community agents** are under `contributors/<agent-name>/` (not repo root). _(N/A — this is a maintainer/official example added at the repo root alongside `fet-example/` and `gemini-quickstart/`, as permitted by `CONTRIBUTING.md`.)_
- [x] I ran `ruff check .` _(passes — `All checks passed!` on `news-card-agent/`)._
- [x] I ran `ruff format .` _(applied — `6 files already formatted` on `news-card-agent/`)._
- [x] I added/updated `README.md` for changed example(s) _(new `news-card-agent/README.md` styled like `a2a-uAgents-Integration/.../langgraph/readme.md`, and registered in the root `README.md` LLM Integration index table)._
- [x] I added `.env.example` if environment variables are required _(documents `ASI_ONE_API_KEY`, `ASI_ONE_MODEL`, `TAVILY_API_KEY`, `NEWS_API_KEY`, `NEWS_API_COUNTRY`)._
- [ ] I added demo image/GIF (if applicable). _(Not added in this PR — happy to follow up with an ASI:One screenshot of the news + detail card if requested.)_
- [ ] I added agent profile link (if applicable). _(Agent is local-mailbox only at this point; no Agentverse profile URL yet.)_
- [x] I updated `contributors/CHANGELOG.md` for community agent changes, or root `CHANGELOG.md` for other non-doc changes _(root `CHANGELOG.md` updated — this is a maintainer example, so the root changelog is the correct file)._
- [x] I added my agent to the **Community Contributors** table in root `README.md` (if new agent). _(N/A — official root example. Added to the **LLM Integration** index table instead.)_
- [x] I verified paths/commands used in docs _(install, run, env block, ASI:One queries, simulated button-click JSON all match the source)._
- [x] I understand this PR **requires maintainer review** before merge (`review-required` CI).

## Related Issue

None.

## Notes for Reviewers

- **No payment protocol**: only the standard chat protocol is included via `agent.include(chat_proto, publish_manifest=True)`. There is no `payment.py` and no FET/Stripe code paths.
- **Card wire format**: each `ChatMessage` carries a `TextContent` preamble + one `MetadataContent` block with `card_protocol_version: "1"`, `requires_card_interaction: "true"`, `card_kind: "custom"`, and `card_payload` JSON-stringified — matches the [agent-driven interactive cards spec](https://docs.agentverse.ai/documentation/advanced-usages/agent-driven-interactive-cards).
- **Payload limits**: element-tree depth = 5 (list card) and 3 (detail card); payload size ≈ 1.3 KB / 0.9 KB. Well under the 8-level / 64 KB spec limits.
- **Selection round-trip**: `shared.parse_card_selection()` handles both inbound formats (raw JSON for direct `@mention`, regex over prose for the planner path) and is unit-checked for `article_id`, `back_to_news`, and "not a selection" cases.
- **Zero-config run**: omitting all news keys works — the agent falls back to the public Hacker News Firebase API and uses picsum-seeded placeholder images. Adding `TAVILY_API_KEY` (or `NEWS_API_KEY`) upgrades it automatically.
- **Country handling**: `NEWS_API_COUNTRY=any` (or blank, `all`, `global`, `world`) skips the country filter and routes the request through NewsAPI `/everything` so the call never fails the "country/category/sources required" validation.
- **Live verified**: a real Tavily call was made during development with `query="latest tech news"` — returned 3 articles with real image URLs and source domains (cnbc.com, cnet.com), confirming the request shape and response parsing.
- **Suggested testing flow**: `python agent.py` → on ASI:One send `latest tech news` → tap any **Read Full Article** → tap **Back to News**. The detail card also includes a markdown link `[Open original article](<url>)` in the chat bubble.


Made with [Cursor](https://cursor.com)