### PR TITLE
fix: handle examples without requirements in setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-COPY ${EXAMPLE}/requirements.txt ./requirements.txt
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt
-
 COPY ${EXAMPLE}/ ./
+
+RUN pip install --no-cache-dir --upgrade pip && \
+    if [ -f requirements.txt ]; then \
+        pip install --no-cache-dir -r requirements.txt; \
+    else \
+        echo "No requirements.txt found for ${EXAMPLE}; skipping dependency install."; \
+    fi
 
 RUN if [ -f .env.example ] && [ ! -f .env ]; then cp .env.example .env; fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -87,7 +87,18 @@ else
     echo "[2/4] Virtual environment already exists."
 fi
 
-source .venv/bin/activate
+ACTIVATE_SCRIPT=""
+if [[ -f ".venv/bin/activate" ]]; then
+    ACTIVATE_SCRIPT=".venv/bin/activate"
+elif [[ -f ".venv/Scripts/activate" ]]; then
+    ACTIVATE_SCRIPT=".venv/Scripts/activate"
+else
+    echo "Error: Could not find a virtual environment activation script."
+    echo "Expected .venv/bin/activate or .venv/Scripts/activate."
+    exit 1
+fi
+
+source "$ACTIVATE_SCRIPT"
 
 if [[ -f "requirements.txt" ]]; then
     echo "[3/4] Installing dependencies..."
@@ -118,7 +129,7 @@ echo ""
 echo "=== Setup Complete ==="
 echo ""
 echo "To activate the environment:"
-echo "  cd $EXAMPLE && source .venv/bin/activate"
+echo "  cd $EXAMPLE && source $ACTIVATE_SCRIPT"
 echo ""
 
 if [[ -n "$ENTRY_FILE" ]]; then


### PR DESCRIPTION
## Summary

- copies the selected example before dependency installation so Docker builds do not fail when an example has no requirements.txt
- installs Python dependencies only when requirements.txt exists
- makes setup.sh source either .venv/bin/activate or .venv/Scripts/activate for Unix and Git Bash/MSYS virtualenv layouts
- updates the printed activation hint to match the detected activation script

## Verification

- bash -n setup.sh
- git diff --check
- docker --version (not available in this local environment, so I could not run a Docker build here)

Fixes #143
