### PR TITLE
fix: add frontend agent request timeouts

### DIFF
--- a/frontend-integration/README.md
+++ b/frontend-integration/README.md
@@ -140,6 +140,7 @@ User Query → Search Agent → Product List → Info Agent → Full Details
 - Comprehensive error messages with request details
 - Graceful handling of API failures
 - Frontend displays user-friendly error messages
+- Frontend requests to local agents use a 5-second timeout so stalled agents return controlled JSON errors instead of hanging the UI
 
 ## 🛠️ Technical Details
 
@@ -155,4 +156,4 @@ User Query → Search Agent → Product List → Info Agent → Full Details
 
 ---
 
-**Ready to explore? Start the agents in separate terminals and open the web interface! 🚀** 
+**Ready to explore? Start the agents in separate terminals and open the web interface! 🚀**

--- a/frontend-integration/frontend_app.py
+++ b/frontend-integration/frontend_app.py
@@ -9,6 +9,7 @@ AGENTS = {
     "search": "http://127.0.0.1:8001",
     "info": "http://127.0.0.1:8002"
 }
+AGENT_REQUEST_TIMEOUT = 5
 
 @app.route('/')
 def index():
@@ -24,7 +25,11 @@ def search_products():
         
         # Call search agent with POST request
         payload = {"query": query}
-        response = requests.post(f"{AGENTS['search']}/search", json=payload)
+        response = requests.post(
+            f"{AGENTS['search']}/search",
+            json=payload,
+            timeout=AGENT_REQUEST_TIMEOUT
+        )
         response.raise_for_status()
         
         # Agent returns JSON directly
@@ -65,7 +70,11 @@ def get_product_info():
         
         # Call info agent with POST request
         payload = {"barcode": barcode}
-        response = requests.post(f"{AGENTS['info']}/product", json=payload)
+        response = requests.post(
+            f"{AGENTS['info']}/product",
+            json=payload,
+            timeout=AGENT_REQUEST_TIMEOUT
+        )
         response.raise_for_status()
         
         # Agent returns JSON directly
@@ -111,7 +120,7 @@ def health_check():
     
     for agent_name, agent_url in AGENTS.items():
         try:
-            response = requests.get(f"{agent_url}/health", timeout=5)
+            response = requests.get(f"{agent_url}/health", timeout=AGENT_REQUEST_TIMEOUT)
             if response.status_code == 200:
                 # Health endpoint returns JSON directly
                 health_data = response.json()
@@ -128,4 +137,4 @@ if __name__ == '__main__':
     print("Available endpoints:")
     print("- Main interface: http://127.0.0.1:5000")
     print("- Health check: http://127.0.0.1:5000/health")
-    app.run(host='127.0.0.1', port=5000, debug=True) 
+    app.run(host='127.0.0.1', port=5000, debug=True)


### PR DESCRIPTION
## Summary
- add a shared 5-second frontend agent request timeout
- apply the timeout to search and product info POST calls
- document the timeout behavior in the frontend integration README

Fixes #148

## Verification
- git diff --check
- python3 -c "from pathlib import Path; compile(Path('frontend-integration/frontend_app.py').read_text(), 'frontend-integration/frontend_app.py', 'exec'); print('syntax ok')"
- mocked Flask test-client check that both POST routes pass timeout=5 and timeout failures return JSON errors