### PR TITLE
ci: add GSSoC '26 label system for dashboard tracking

### DIFF
--- a/.github/labels/gssoc-labels.json
+++ b/.github/labels/gssoc-labels.json
@@ -1,0 +1,38 @@
+{
+  "program": [
+    { "name": "gssoc26", "color": "ff6d00", "description": "GirlScript Summer of Code 2026 contribution" }
+  ],
+  "level": [
+    { "name": "level1", "color": "00c853", "description": "GSSoC level 1 - beginner friendly (lowest points)" },
+    { "name": "level2", "color": "fbc02d", "description": "GSSoC level 2 - intermediate (medium points)" },
+    { "name": "level3", "color": "d50000", "description": "GSSoC level 3 - advanced (highest points)" }
+  ],
+  "difficulty": [
+    { "name": "level:beginner", "color": "7057ff", "description": "GSSoC difficulty: beginner-friendly task" },
+    { "name": "level:intermediate", "color": "fbca04", "description": "GSSoC difficulty: intermediate-level task" },
+    { "name": "level:advanced", "color": "d93f0b", "description": "GSSoC difficulty: advanced-level task" },
+    { "name": "level:critical", "color": "b60205", "description": "GSSoC difficulty: critical-level task" }
+  ],
+  "quality": [
+    { "name": "quality:clean", "color": "0e8a16", "description": "GSSoC quality: clean, well-structured code" },
+    { "name": "quality:exceptional", "color": "006b75", "description": "GSSoC quality: exceptional contribution (optional bonus)" }
+  ],
+  "type_bonus": [
+    { "name": "type:docs", "color": "0075ca", "description": "GSSoC bonus: documentation improvement" },
+    { "name": "type:testing", "color": "bfd4f2", "description": "GSSoC bonus: test coverage improvement" },
+    { "name": "type:accessibility", "color": "d4c5f9", "description": "GSSoC bonus: accessibility improvement" },
+    { "name": "type:performance", "color": "f9d0c4", "description": "GSSoC bonus: performance optimization" },
+    { "name": "type:security", "color": "b60205", "description": "GSSoC bonus: security fix or improvement" },
+    { "name": "type:design", "color": "c5def5", "description": "GSSoC bonus: UI/UX design improvement" },
+    { "name": "type:refactor", "color": "fef2c0", "description": "GSSoC bonus: code refactoring" },
+    { "name": "type:devops", "color": "1d76db", "description": "GSSoC bonus: DevOps or CI/CD improvement" },
+    { "name": "type:bug", "color": "d73a4a", "description": "GSSoC bonus: bug fix" },
+    { "name": "type:feature", "color": "a2eeef", "description": "GSSoC bonus: new feature implementation" }
+  ],
+  "validation": [
+    { "name": "gssoc:approved", "color": "0e8a16", "description": "GSSoC validation: approved by Project Admin" },
+    { "name": "gssoc:invalid", "color": "e4e669", "description": "GSSoC validation: marked invalid by Project Admin" },
+    { "name": "gssoc:spam", "color": "b60205", "description": "GSSoC validation: marked as spam" },
+    { "name": "gssoc:ai-slop", "color": "d93f0b", "description": "GSSoC validation: AI-generated low-effort contribution" }
+  ]
+}

--- a/.github/scripts/create-gssoc-labels.sh
+++ b/.github/scripts/create-gssoc-labels.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# .github/scripts/create-gssoc-labels.sh
+#
+# Bootstraps the GSSoC label set on a repository so the GSSoC dashboard can
+# track contributions. Creates (or updates) every label defined in
+# .github/labels/gssoc-labels.json:
+#   - program  : gssoc26
+#   - level    : level1, level2, level3 (points tiers read by the dashboard)
+#   - difficulty / quality / type_bonus / validation : triage + bonus labels
+#
+# Usage:
+#   bash .github/scripts/create-gssoc-labels.sh                       # current repo
+#   bash .github/scripts/create-gssoc-labels.sh fetchai/innovation-lab-examples
+#
+# Requirements:
+#   - GitHub CLI (gh), authenticated with repo write access
+#   - jq
+
+set -euo pipefail
+
+REPO="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LABELS_FILE="$SCRIPT_DIR/../labels/gssoc-labels.json"
+
+if [[ ! -f "$LABELS_FILE" ]]; then
+  echo "Labels file not found: $LABELS_FILE" >&2
+  exit 1
+fi
+
+REPO_ARG=()
+if [[ -n "$REPO" ]]; then
+  REPO_ARG+=(--repo "$REPO")
+fi
+
+upsert_label() {
+  local name="$1"
+  local color="$2"
+  local description="$3"
+
+  if gh label list "${REPO_ARG[@]}" \
+      --search "$name" \
+      --json name \
+      --jq '.[].name' \
+      2>/dev/null | grep -Fxq "$name"; then
+    printf '  updated  %s\n' "$name"
+    gh label edit "$name" \
+      --color "$color" \
+      --description "$description" \
+      "${REPO_ARG[@]}" \
+      >/dev/null 2>&1
+  else
+    printf '  created  %s\n' "$name"
+    gh label create "$name" \
+      --color "$color" \
+      --description "$description" \
+      "${REPO_ARG[@]}" \
+      >/dev/null
+  fi
+}
+
+sync_group() {
+  local group="$1"
+  local count
+  count="$(jq -r --arg g "$group" '.[$g] // [] | length' "$LABELS_FILE")"
+  if [[ "$count" == "0" ]]; then
+    return
+  fi
+  echo "-- ${group} labels --"
+  # Tab-separated so names/descriptions with spaces survive the read.
+  jq -r --arg g "$group" '.[$g][] | [.name, .color, .description] | @tsv' "$LABELS_FILE" \
+    | while IFS=$'\t' read -r name color description; do
+        upsert_label "$name" "$color" "$description"
+      done
+  echo ""
+}
+
+echo "=== GSSoC Label Bootstrap ==="
+echo "Repo: ${REPO:-<current>}"
+echo ""
+
+sync_group "program"
+sync_group "level"
+sync_group "difficulty"
+sync_group "quality"
+sync_group "type_bonus"
+sync_group "validation"
+
+echo "GSSoC labels synchronized successfully."

--- a/.github/workflows/gssoc-label-bootstrap.yml
+++ b/.github/workflows/gssoc-label-bootstrap.yml
@@ -1,0 +1,35 @@
+name: GSSoC Label Bootstrap
+
+# Creates/updates the GSSoC label set defined in
+# .github/labels/gssoc-labels.json so the GSSoC dashboard can track
+# contributions. Runs on manual dispatch and whenever the label definitions
+# (or this workflow/script) change on the default branch.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/labels/gssoc-labels.json"
+      - ".github/scripts/create-gssoc-labels.sh"
+      - ".github/workflows/gssoc-label-bootstrap.yml"
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: gssoc-label-bootstrap
+  cancel-in-progress: true
+
+jobs:
+  bootstrap-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create / update GSSoC labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash .github/scripts/create-gssoc-labels.sh "${{ github.repository }}"

--- a/.github/workflows/gssoc-label-sync.yml
+++ b/.github/workflows/gssoc-label-sync.yml
@@ -1,0 +1,114 @@
+name: GSSoC Sync Issue Labels to PR
+
+# When a PR links an issue (e.g. "Closes #123"), copy the GSSoC tracking
+# labels from that issue onto the PR. The GSSoC dashboard reads the program
+# (gssoc26) and level (level1/level2/level3) labels from MERGED PRs to award
+# points, so this keeps a contributor's PR in sync with the triaged issue.
+#
+# Uses pull_request_target so it can label PRs opened from forks. It only ever
+# reads the PR body + linked issue labels and adds a fixed allow-list of
+# labels — it never runs untrusted PR code.
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  issues: read
+
+concurrency:
+  group: gssoc-label-sync-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
+    steps:
+      - name: Sync safe GSSoC labels from linked issues
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const { owner, repo } = context.repo;
+
+            if (pr.user.type === 'Bot') {
+              core.info('Skipping bot PR');
+              return;
+            }
+
+            // Only these labels are ever auto-applied to a PR.
+            const SAFE_LABELS = new Set([
+              'gssoc26',
+              'level1',
+              'level2',
+              'level3',
+              'level:beginner',
+              'level:intermediate',
+              'level:advanced',
+              'level:critical',
+              'bug',
+              'enhancement',
+              'documentation',
+              'good first issue',
+              'help wanted',
+            ]);
+
+            const body = pr.body || '';
+            const matches = body.match(
+              /\b(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s+#(\d+)/gi
+            ) || [];
+
+            const issueNumbers = [...new Set(
+              matches
+                .map((m) => {
+                  const found = m.match(/#(\d+)/);
+                  return found ? parseInt(found[1], 10) : null;
+                })
+                .filter(Boolean)
+            )];
+
+            if (issueNumbers.length === 0) {
+              core.info('No linked issues found');
+              return;
+            }
+
+            const labelsToAdd = new Set();
+            for (const issue_number of issueNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number,
+                });
+                if (issue.pull_request) continue;
+                for (const label of issue.labels || []) {
+                  const name = typeof label === 'string' ? label : label.name;
+                  if (name && SAFE_LABELS.has(name.toLowerCase())) {
+                    labelsToAdd.add(name);
+                  }
+                }
+              } catch (e) {
+                core.info(`Failed fetching issue #${issue_number}: ${e.message}`);
+              }
+            }
+
+            if (labelsToAdd.size === 0) {
+              core.info('No safe labels to sync');
+              return;
+            }
+
+            const labels = Array.from(labelsToAdd);
+            try {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pr.number,
+                labels,
+              });
+              core.info(`Synced labels: ${labels.join(', ')}`);
+            } catch (e) {
+              core.warning(`Failed syncing labels: ${e.message}`);
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ dmypy.json
 !package.json
 !tsconfig.json
 !contributors/BADGE_REGISTRY.json
+!.github/labels/gssoc-labels.json
 !pyproject.toml
 
 # Docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this repository are documented in this file.
 ## [Unreleased]
 
 ### Added
+- GSSoC '26 label system: [.github/labels/gssoc-labels.json](.github/labels/gssoc-labels.json) definitions, [.github/scripts/create-gssoc-labels.sh](.github/scripts/create-gssoc-labels.sh) bootstrap script, `gssoc-label-bootstrap` workflow (auto-create/update labels), `gssoc-label-sync` workflow (copy `gssoc26`/`level1-3` labels from linked issues to PRs for dashboard tracking), and [docs/GSSOC.md](docs/GSSOC.md) guide
 - `langchain-agents/deep-agents/hackflow-agent/`: LangChain Deep Agents hackathon intelligence agent for ASI:One. Three-subagent research pipeline (event_finder, sponsor_researcher, winner_researcher), Stripe-gated full analysis, ASI:One primary LLM with fallbacks, Tavily web search, and persisted cross-turn follow-up memory.
 - `news-card-agent/`: ASI:One interactive-cards example. Live news rendered as a `card_kind: "custom"` element-tree (section → list of items with image, heading, text, badge, and a "Read Full Article" button). Tapping a button opens a fresh detail card. Multi-backend news cascade (Tavily → NewsAPI.org → Hacker News), ASI1 LLM-polished card copy, and no payment protocol.
 - Auto badge workflow [award-contributor-badge.yml](.github/workflows/award-contributor-badge.yml) for merged external contributor PRs; [BADGE_REGISTRY.json](contributors/BADGE_REGISTRY.json) and [profile-badge-sync](contributors/profile-badge-sync/) for GitHub Profile README

--- a/docs/GSSOC.md
+++ b/docs/GSSOC.md
@@ -1,0 +1,88 @@
+# GSSoC '26 — Labels & Contribution Tracking
+
+This repository participates in **GirlScript Summer of Code 2026 (GSSoC '26)**.
+The GSSoC dashboard awards points to contributors based on labels attached to
+their **merged pull requests**. This document explains the label system we use
+and how points are tracked automatically.
+
+## How tracking works
+
+```mermaid
+flowchart LR
+    A[Maintainer triages issue] -->|adds gssoc26 + level1/2/3| B[Issue labeled]
+    B --> C[Contributor opens PR<br/>with 'Closes #issue']
+    C --> D[gssoc-label-sync workflow<br/>copies labels issue -> PR]
+    D --> E[Maintainer merges PR]
+    E --> F[GSSoC dashboard reads<br/>gssoc26 + level on merged PR]
+    F --> G[Points credited to contributor]
+```
+
+1. A maintainer labels an **issue** with `gssoc26` and a level (`level1`,
+   `level2`, or `level3`).
+2. A contributor opens a PR that links the issue using a closing keyword
+   (e.g. `Closes #123`, `Fixes #123`).
+3. The [`gssoc-label-sync`](../.github/workflows/gssoc-label-sync.yml) workflow
+   copies the safe GSSoC labels from the linked issue onto the PR.
+4. When the PR is merged, the GSSoC dashboard reads `gssoc26` + the level label
+   and credits points to the contributor.
+
+> Important: link the issue in your PR description with `Closes #<number>` so
+> the labels (and your points) sync automatically.
+
+## Label set
+
+All labels are defined in
+[`.github/labels/gssoc-labels.json`](../.github/labels/gssoc-labels.json) and
+created by the bootstrap workflow.
+
+### Program
+
+| Label | Meaning |
+| --- | --- |
+| `gssoc26` | Counts as a GSSoC '26 contribution |
+
+### Level (points tiers read by the dashboard)
+
+| Label | Tier | Typical scope |
+| --- | --- | --- |
+| `level1` | Lowest points | Beginner-friendly, small change |
+| `level2` | Medium points | Intermediate feature/fix |
+| `level3` | Highest points | Advanced / substantial work |
+
+### Triage & bonus labels
+
+| Group | Labels |
+| --- | --- |
+| Difficulty | `level:beginner`, `level:intermediate`, `level:advanced`, `level:critical` |
+| Quality | `quality:clean`, `quality:exceptional` |
+| Type bonus | `type:docs`, `type:testing`, `type:accessibility`, `type:performance`, `type:security`, `type:design`, `type:refactor`, `type:devops`, `type:bug`, `type:feature` |
+| Validation | `gssoc:approved`, `gssoc:invalid`, `gssoc:spam`, `gssoc:ai-slop` |
+
+## Creating the labels in the repo
+
+Labels are created/updated automatically by the
+[`gssoc-label-bootstrap`](../.github/workflows/gssoc-label-bootstrap.yml)
+workflow:
+
+- **Automatically** whenever `.github/labels/gssoc-labels.json` changes on
+  `main`.
+- **Manually** from the GitHub UI: *Actions → GSSoC Label Bootstrap → Run
+  workflow*.
+
+You can also run it locally with the GitHub CLI:
+
+```bash
+# requires: gh (authenticated with repo write access) + jq
+bash .github/scripts/create-gssoc-labels.sh fetchai/innovation-lab-examples
+```
+
+The script is **idempotent** — it updates existing labels and never deletes
+labels that are not in the JSON, so it is safe to re-run.
+
+## For contributors (quick reference)
+
+1. Pick an issue labeled `gssoc26` + a level.
+2. Comment to get assigned (per `CONTRIBUTING.md`).
+3. Open your PR with `Closes #<issue-number>` in the description.
+4. The level/program labels sync to your PR automatically.
+5. After merge, points appear on the GSSoC dashboard.


### PR DESCRIPTION
## Summary

Sets up the GSSoC '26 label system so the GSSoC dashboard can track contributor points on this repo. Modeled on the GSSoC reference setup in `S3DFX-CYBER/GSoC-Org-Finder-` but trimmed to just the label/tracking essentials.

The GSSoC dashboard awards points based on labels on **merged PRs** — specifically the program label `gssoc26` and the level tiers `level1` / `level2` / `level3`. This PR adds:

- **`.github/labels/gssoc-labels.json`** — 24 labels across `program`, `level`, `difficulty`, `quality`, `type_bonus`, and `validation` groups.
- **`.github/scripts/create-gssoc-labels.sh`** — idempotent `gh`+`jq` bootstrap that creates/updates every label from the JSON (never deletes existing labels; safe to re-run).
- **`.github/workflows/gssoc-label-bootstrap.yml`** — runs the script on manual dispatch and whenever the labels JSON changes on `main` (`issues: write`).
- **`.github/workflows/gssoc-label-sync.yml`** — when a PR links an issue (`Closes #123`), copies the safe GSSoC labels from that issue onto the PR (`pull_request_target`, fixed allow-list, fork-safe) so points sync automatically on merge.
- **`docs/GSSOC.md`** — contributor + maintainer guide with a tracking flow diagram.
- **`.gitignore`** — allow the labels JSON past the global `*.json` ignore (same pattern as `contributors/BADGE_REGISTRY.json`).

## Type of Change

- [ ] New agent example
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactor / cleanup
- [x] Other (CI / DevOps — GSSoC label tracking)

## How tracking works

1. Maintainer labels an **issue** with `gssoc26` + a level (`level1/2/3`).
2. Contributor opens a PR with `Closes #<issue>`.
3. `gssoc-label-sync` copies the labels from the issue to the PR.
4. On merge, the GSSoC dashboard reads `gssoc26` + level and credits points.

## Activating the labels after merge

Labels are created by the bootstrap workflow: either it runs automatically (the JSON changes on `main` in this PR), or a maintainer triggers **Actions → GSSoC Label Bootstrap → Run workflow**. It can also be run locally:

```bash
bash .github/scripts/create-gssoc-labels.sh fetchai/innovation-lab-examples
```

## Validation done

- `gssoc-labels.json` parses; 24 labels across 6 groups.
- Both workflows parse as valid YAML.
- `bash -n` passes on the bootstrap script; jq `@tsv` parsing dry-run produces correct name/color/description for every label.
- Script committed with `100755` (executable) mode.

## Notes for Reviewers

- `gssoc-label-sync.yml` uses `pull_request_target` (needed to label fork PRs) but only ever reads the PR body + linked-issue labels and adds a fixed allow-list — it never checks out or runs PR code.
- The bootstrap script is non-destructive (upsert only); it will not remove labels that already exist on the repo.
- No labels are created by this PR itself; creation happens via the workflow/script after merge (or manual dispatch).