### PR TITLE
fix: add missing .env.example files to agent examples (closes #35)

### DIFF
--- a/Browser-based-agents/.env.example
+++ b/Browser-based-agents/.env.example
@@ -1,0 +1,32 @@
+# ASI One LLM
+# Get your API key from: https://asi1.ai/
+ASI_ONE_API_KEY=your-asi-one-api-key-here
+ASI_ONE_CHAT_MODEL=asi1-mini
+
+# Agentverse / Fetch.ai
+# Get your API key from: https://agentverse.ai/
+AGENTVERSE_API_KEY=your-agentverse-api-key-here
+AGENTVERSE_URL=https://agentverse.ai
+
+# Notte Labs (Nike-products-agent only)
+# Get your API key from: https://notte.cc/
+NOTTE_API_KEY=your-notte-api-key-here
+
+# Stripe (job-application-agent only)
+# Get your API keys from: https://dashboard.stripe.com/
+STRIPE_SECRET_KEY=your-stripe-secret-key-here
+STRIPE_PUBLISHABLE_KEY=your-stripe-publishable-key-here
+STRIPE_PRODUCT_NAME=Job Application Service
+STRIPE_AMOUNT_CENTS=1000
+STRIPE_CURRENCY=usd
+STRIPE_SUCCESS_URL=http://localhost:8000/success
+STRIPE_CHECKOUT_EXPIRES_SECONDS=1800
+
+# Job Application Agent Configuration
+ORCHESTRATOR_AGENT_PORT=8000
+DEFAULT_RESUME_PATH=resume.pdf
+DEFAULT_USER_KEY=your-user-key-here
+PAYMENT_ENABLED=false
+LIVE_FILL_MODE=false
+LIVE_FILL_SCREENSHOT_EVERY=5
+SUBMITTER_DEFAULT_DRY_RUN=true

--- a/Composio/.env.example
+++ b/Composio/.env.example
@@ -1,0 +1,13 @@
+# Composio
+# Get your API key from: https://app.composio.dev/
+COMPOSIO_API_KEY=your-composio-api-key-here
+
+# OpenAI
+# Get your API key from: https://platform.openai.com/
+OPENAI_API_KEY=your-openai-api-key-here
+OPENAI_MODEL=gpt-4o
+
+# Composio Auth Config IDs
+# Set these up in your Composio dashboard
+GMAIL_AUTH_CONFIG_ID=your-gmail-auth-config-id-here
+LINKEDIN_AUTH_CONFIG_ID=your-linkedin-auth-config-id-here

--- a/Crewai-agents/.env.example
+++ b/Crewai-agents/.env.example
@@ -1,0 +1,22 @@
+# Agentverse / Fetch.ai
+# Get your API key from: https://agentverse.ai/
+AGENTVERSE_API_KEY=your-agentverse-api-key-here
+
+# Used by trip_planner agent (alias for AGENTVERSE_API_KEY)
+AV_API_KEY=your-agentverse-api-key-here
+
+# OpenAI
+# Get your API key from: https://platform.openai.com/
+OPENAI_API_KEY=your-openai-api-key-here
+
+# Serper Search (Blood-Report-Analysis-Agent only)
+# Get your API key from: https://serper.dev/
+SERPER_API_KEY=your-serper-api-key-here
+
+# Exa Search (Prep-for-a-meeting-Agent only)
+# Get your API key from: https://exa.ai/
+EXA_API_KEY=your-exa-api-key-here
+
+# OpenWeather (trip_planner only)
+# Get your API key from: https://openweathermap.org/api/
+OPENWEATHER_API_KEY=your-openweather-api-key-here

--- a/Rag-agent/.env.example
+++ b/Rag-agent/.env.example
@@ -1,0 +1,3 @@
+# OpenAI
+# Get your API key from: https://platform.openai.com/
+OPENAI_API_KEY=your-openai-api-key-here

--- a/a2a-uAgents-Integration/.env.example
+++ b/a2a-uAgents-Integration/.env.example
@@ -1,0 +1,20 @@
+# ASI1 / Fetch.ai LLM Configuration
+# Get your API key from: https://asi1.ai/
+ASI1_API_KEY=your-asi1-api-key-here
+ASI1_API_URL=https://api.asi1.ai/v1/chat/completions
+ASI1_MODEL=asi1-mini
+
+# Coordinator LLM
+MODEL=asi1-mini
+BASE_URL=https://api.asi1.ai/v1/chat/completions
+
+# Brave Search (braveagent only)
+# Get your API key from: https://brave.com/search/api/
+BRAVE_API_KEY=your-brave-api-key-here
+
+# OpenAI (youtube_summarizer only)
+# Get your API key from: https://platform.openai.com/
+OPENAI_API_KEY=your-openai-api-key-here
+
+# uAgents Timeout (optional, defaults to 300 seconds)
+UAGENT_MESSAGE_TIMEOUT=300

--- a/ag2-agents/.env.example
+++ b/ag2-agents/.env.example
@@ -1,0 +1,14 @@
+# OpenAI
+# Get your API key from: https://platform.openai.com/
+OPENAI_API_KEY=your-openai-api-key-here
+OPENAI_BASE_URL=https://api.openai.com/v1
+
+# Agent Configuration
+# Get your seed phrase from: https://agentverse.ai/
+AGENT_SEED=your-agent-seed-phrase-here
+AGENT_PORT=8000
+A2A_PORT=8001
+LLM_MODEL=gpt-4o
+
+# MCP Server (research-synthesis-team only)
+MCP_SERVER_URL=your-mcp-server-url-here

--- a/anthropic-quickstart/.env.example
+++ b/anthropic-quickstart/.env.example
@@ -1,0 +1,3 @@
+# Anthropic
+# Get your API key from: https://console.anthropic.com/
+ANTHROPIC_API_KEY=your-anthropic-api-key-here

--- a/asi1-llm-example/.env.example
+++ b/asi1-llm-example/.env.example
@@ -1,0 +1,7 @@
+# ASI1 / Fetch.ai LLM
+# Get your API key from: https://asi1.ai/
+ASI_LLM_KEY=your-asi1-api-key-here
+
+# Tavily Search
+# Get your API key from: https://tavily.com/
+TAVILY_API_KEY=your-tavily-api-key-here

--- a/contributors/.env.example
+++ b/contributors/.env.example
@@ -1,0 +1,7 @@
+# ASI One LLM
+# Get your API key from: https://asi1.ai/
+ASI_ONE_API_KEY=your-asi-one-api-key-here
+
+# Tavily Search
+# Get your API key from: https://tavily.com/
+TAVILY_API_KEY=your-tavily-api-key-here

--- a/gemini-quickstart/.env.example
+++ b/gemini-quickstart/.env.example
@@ -1,0 +1,22 @@
+# Google Gemini
+# Get your API key from: https://aistudio.google.com/
+GEMINI_API_KEY=your-gemini-api-key-here
+
+# Google Cloud (07-short-film-agent only)
+GOOGLE_CLOUD_PROJECT=your-google-cloud-project-id
+GCS_BUCKET_NAME=your-gcs-bucket-name
+GCS_CREDENTIALS_BASE64=your-base64-encoded-gcp-credentials
+
+# Agentverse / Fetch.ai
+# Get your API key from: https://agentverse.ai/
+AGENTVERSE_URL=https://agentverse.ai
+
+# Stripe (07-short-film-agent only)
+# Get your API keys from: https://dashboard.stripe.com/
+STRIPE_SECRET_KEY=your-stripe-secret-key-here
+STRIPE_PUBLISHABLE_KEY=your-stripe-publishable-key-here
+STRIPE_PRODUCT_NAME=Short Film Service
+STRIPE_AMOUNT_CENTS=1000
+STRIPE_CURRENCY=usd
+STRIPE_SUCCESS_URL=http://localhost:8000/success
+STRIPE_CHECKOUT_EXPIRES_SECONDS=1800

--- a/google-adk/.env.example
+++ b/google-adk/.env.example
@@ -1,0 +1,37 @@
+# Google Gemini / ADK
+# Get your API key from: https://aistudio.google.com/
+GEMINI_API_KEY=your-gemini-api-key-here
+GOOGLE_API_KEY=your-google-api-key-here
+GOOGLE_CLOUD_PROJECT=your-google-cloud-project-id
+
+# Model Armor (adk-security-agent only)
+MODEL_ARMOR_LOCATION=us-central1
+
+# ADK GCS Bucket (ai-due-diligence-agent only)
+ADK_GCS_BUCKET_NAME=your-gcs-bucket-name
+
+# ASI1 / Fetch.ai LLM (google-trends-agent only)
+# Get your API key from: https://asi1.ai/
+ASI1_API_KEY=your-asi1-api-key-here
+
+# Firecrawl (ai-seo-audit-team only)
+# Get your API key from: https://firecrawl.dev/
+FIRECRAWL_API_KEY=your-firecrawl-api-key-here
+
+# Agent Configuration (google-trends-agent only)
+AGENT_SEED=your-agent-seed-phrase-here
+AGENT_PORT=8000
+
+# AI Due Diligence Agent
+AI_DUE_DILIGENCE_AGENT_SEED=your-agent-seed-phrase-here
+AI_DUE_DILIGENCE_AGENT_PORT=8001
+
+# Stripe (google-trends-agent only)
+# Get your API keys from: https://dashboard.stripe.com/
+STRIPE_SECRET_KEY=your-stripe-secret-key-here
+STRIPE_PUBLISHABLE_KEY=your-stripe-publishable-key-here
+STRIPE_PRODUCT_NAME=Google Trends Service
+STRIPE_AMOUNT_CENTS=1000
+STRIPE_CURRENCY=usd
+STRIPE_SUCCESS_URL=http://localhost:8000/success
+STRIPE_CHECKOUT_EXPIRES_SECONDS=1800

--- a/google-genai-parallel-processing/.env.example
+++ b/google-genai-parallel-processing/.env.example
@@ -1,0 +1,12 @@
+# ASI1 / Fetch.ai LLM
+# Get your API key from: https://asi1.ai/
+ASI1_API_KEY=your-asi1-api-key-here
+
+# OpenAI
+# Get your API key from: https://platform.openai.com/
+OPENAI_API_KEY=your-openai-api-key-here
+
+# Agentverse / Fetch.ai
+# Get your API key from: https://agentverse.ai/
+AGENTVERSE_API_KEY=your-agentverse-api-key-here
+AGENTVERSE_URL=https://agentverse.ai

--- a/langchain-agents/.env.example
+++ b/langchain-agents/.env.example
@@ -1,0 +1,25 @@
+# Anthropic
+# Get your API key from: https://console.anthropic.com/
+ANTHROPIC_API_KEY=your-anthropic-api-key-here
+
+# ASI1 / Fetch.ai LLM
+# Get your API key from: https://asi1.ai/
+ASI1_API_KEY=your-asi1-api-key-here
+
+# Tavily Search
+# Get your API key from: https://tavily.com/
+TAVILY_API_KEY=your-tavily-api-key-here
+
+# Agent Configuration
+AGENT_NAME=hackflow-agent
+AGENT_SEED=your-agent-seed-phrase-here
+AGENT_PORT=8000
+
+# Stripe
+# Get your API keys from: https://dashboard.stripe.com/
+STRIPE_SECRET_KEY=your-stripe-secret-key-here
+STRIPE_PUBLISHABLE_KEY=your-stripe-publishable-key-here
+STRIPE_CURRENCY=usd
+STRIPE_AMOUNT_CENTS=1000
+STRIPE_SUCCESS_URL=http://localhost:8000/success
+STRIPE_CHECKOUT_EXPIRES_SECONDS=1800

--- a/mcp-agents/.env.example
+++ b/mcp-agents/.env.example
@@ -1,0 +1,67 @@
+# Anthropic (airbnb, github, perplexity, context7 agents)
+# Get your API key from: https://console.anthropic.com/
+ANTHROPIC_API_KEY=your-anthropic-api-key-here
+
+# ASI1 / Fetch.ai LLM (events-finder, ticketlens agents)
+# Get your API key from: https://asi1.ai/
+ASI1_API_KEY=your-asi1-api-key-here
+ASI1_MODEL=asi1-mini
+
+# ASI One (TMDB agent)
+ASI_ONE_API_KEY=your-asi-one-api-key-here
+
+# OpenAI (calendar, gmail agents)
+# Get your API key from: https://platform.openai.com/
+OPENAI_API_KEY=your-openai-api-key-here
+OPENAI_MODEL=gpt-4o
+
+# Perplexity MCP Agent
+# Get your API key from: https://www.perplexity.ai/settings/api
+PERPLEXITY_API_KEY=your-perplexity-api-key-here
+
+# Groq (events-finder agent)
+# Get your API key from: https://console.groq.com/
+GROQ_API_KEY=your-groq-api-key-here
+
+# Agentverse / Fetch.ai
+# Get your API key from: https://agentverse.ai/
+AGENTVERSE_API_KEY=your-agentverse-api-key-here
+AGENTVERSE_URL=https://agentverse.ai
+
+# Ticketmaster (events-finder agent)
+# Get your API key from: https://developer.ticketmaster.com/
+TICKETMASTER_API_KEY=your-ticketmaster-api-key-here
+
+# GitHub MCP Agent
+GITHUB_CLIENT_ID=your-github-client-id-here
+
+# MCP Server
+MCP_SERVER_URL=your-mcp-server-url-here
+
+# Agent Configuration (TMDB agent)
+AGENT_SEED=your-agent-seed-phrase-here
+AGENT_PORT=8000
+
+# Calendar Chat Agent
+CAL_CHAT_AGENT_NAME=calendar-chat-agent
+CAL_CHAT_AGENT_SEED=your-agent-seed-phrase-here
+CAL_CHAT_AGENT_PORT=8001
+CAL_CREDENTIALS_FILE=credentials.json
+CAL_TOKENS_DIR=tokens
+CAL_TOKENS_FILE=token.json
+CALENDAR_MCP_PORT=8002
+CALENDAR_MCP_URL=http://localhost:8002
+MAX_CAL_CHAT_HISTORY=10
+
+# Gmail Chat Agent
+GMAIL_CHAT_AGENT_NAME=gmail-chat-agent
+GMAIL_CHAT_AGENT_SEED=your-agent-seed-phrase-here
+GMAIL_CHAT_AGENT_PORT=8003
+GMAIL_TOKENS_DIR=tokens
+GMAIL_MCP_PORT=8004
+GMAIL_MCP_URL=http://localhost:8004
+MAX_GMAIL_CHAT_HISTORY=10
+GMAIL_LOG=gmail.log
+GMAIL_CHAT_LOG=gmail_chat.log
+GMAIL_CHAT_IO_LOG=gmail_chat_io.log
+VERBOSE_GMAIL_LOGS=false

--- a/openai-agent-sdk/.env.example
+++ b/openai-agent-sdk/.env.example
@@ -1,0 +1,29 @@
+# OpenAI
+# Get your API key from: https://platform.openai.com/
+OPENAI_API_KEY=your-openai-api-key-here
+
+# Google Gemini (Appliance Auto Whisperer only)
+# Get your API key from: https://aistudio.google.com/
+GEMINI_API_KEY=your-gemini-api-key-here
+
+# Agentverse / Fetch.ai
+# Get your API key from: https://agentverse.ai/
+AGENTVERSE_API_KEY=your-agentverse-api-key-here
+
+# Agent Configuration
+AGENT_SEED=your-agent-seed-phrase-here
+AGENT_PORT=8000
+AGENT_ENDPOINT=http://localhost:8000
+AGENT_NETWORK=mainnet
+
+# Appliance Auto Whisperer Agent Workers
+ORCHESTRATOR_AGENT_PORT=8000
+TUTORIAL_AGENT_HOST=localhost
+TUTORIAL_AGENT_PORT=8001
+TUTORIAL_AGENT_SEED=your-tutorial-agent-seed-here
+PARTS_AGENT_HOST=localhost
+PARTS_AGENT_PORT=8002
+PARTS_AGENT_SEED=your-parts-agent-seed-here
+REPORTS_BASE_URL=http://localhost:8000/reports
+WORKER_TIMEOUT_S=30
+LOG_LEVEL=INFO

--- a/openclaw/.env.example
+++ b/openclaw/.env.example
@@ -1,0 +1,31 @@
+# ASI One LLM
+# Get your API key from: https://asi1.ai/
+ASI_ONE_API_KEY=your-asi-one-api-key-here
+ASI_ONE_BASE_URL=https://api.asi1.ai/v1
+ASI_ONE_MODEL=asi1-mini
+
+# Agentverse / Fetch.ai
+# Get your API key from: https://agentverse.ai/
+AGENTVERSE_API_KEY=your-agentverse-api-key-here
+
+# Orchestrator Agent
+ORCHESTRATOR_AGENT_SEED=your-orchestrator-seed-here
+ORCHESTRATOR_AGENT_ADDRESS=your-orchestrator-agent-address-here
+ORCHESTRATOR_PORT=8000
+AGENT_NETWORK=mainnet
+
+# Connector Agent
+CONNECTOR_AGENT_SEED=your-connector-seed-here
+CONNECTOR_PORT=8001
+CONNECTOR_USER_ID=your-user-id-here
+CONNECTOR_DEVICE_ID=your-device-id-here
+CONNECTOR_KEY_DIR=keys
+
+# Fetch Agent (agentverse-caller only)
+FETCH_AGENT_SEED=your-fetch-agent-seed-here
+
+# Configuration
+DEMO_PROJECTS_DIR=demo_projects
+MAX_REPO_SIZE_MB=10
+LOG_LEVEL=INFO
+USE_MAILBOX=true

--- a/stripe-payment-agents/.env.example
+++ b/stripe-payment-agents/.env.example
@@ -1,0 +1,50 @@
+# OpenAI
+# Get your API key from: https://platform.openai.com/
+OPENAI_API_KEY=your-openai-api-key-here
+OPENAI_MODEL=gpt-4o
+
+# ASI1 / Fetch.ai LLM
+# Get your API key from: https://asi1.ai/
+ASI1_API_KEY=your-asi1-api-key-here
+ASI_ONE_API_KEY=your-asi-one-api-key-here
+
+# Agentverse / Fetch.ai
+# Get your API key from: https://agentverse.ai/
+AGENTVERSE_API_TOKEN=your-agentverse-api-token-here
+AGENTVERSE_URL=https://agentverse.ai
+
+# Stripe
+# Get your API keys from: https://dashboard.stripe.com/
+STRIPE_SECRET_KEY=your-stripe-secret-key-here
+STRIPE_PUBLISHABLE_KEY=your-stripe-publishable-key-here
+STRIPE_PRODUCT_NAME=Service
+STRIPE_AMOUNT_CENTS=1000
+STRIPE_CURRENCY=usd
+STRIPE_SUCCESS_URL=http://localhost:8000/success
+STRIPE_CHECKOUT_EXPIRES_SECONDS=1800
+
+# Repliers API (conversational-property-finder only)
+# Get your API key from: https://repliers.io/
+REPLIERS_API_KEY=your-repliers-api-key-here
+
+# Email (conversational-property-finder only)
+EMAIL_API_KEY=your-email-api-key-here
+EMAIL_TO=your-email@example.com
+
+# Agent Configuration
+AGENT_SEED=your-agent-seed-phrase-here
+AGENT_PORT=8000
+AGENT_ENDPOINT_URL=http://localhost:8000
+AGENT_SECRET_KEY_1=your-agent-secret-key-here
+USE_MAILBOX=true
+
+# YouTube Growth Analyzer Configuration
+RECENT_VIDEO_MAX_RESULTS=10
+PREMIUM_REPORT_CHUNK_CHARS=2000
+PAYMENT_DEADLINE_SECONDS=300
+STATE_TTL_SECONDS=3600
+LOG_LEVEL=INFO
+LOG_MAILBOX_HELP=true
+MAILBOX_CONNECT_RETRIES=3
+MAILBOX_CONNECT_DELAY_SECONDS=5
+MAILBOX_CONNECT_RETRY_INTERVAL=10

--- a/web3/.env.example
+++ b/web3/.env.example
@@ -1,0 +1,3 @@
+# ASI One LLM
+# Get your API key from: https://asi1.ai/
+ASI_ONE_API_KEY=your-asi-one-api-key-here


### PR DESCRIPTION
## Summary
Added missing `.env.example` files to 18 agent example folders that require environment variables or API keys but had no setup guidance. Each file documents the required variables with placeholder values and links to where users can obtain the actual keys.

## Type of Change
- [ ] New agent example
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactor / cleanup
- [ ] Other

## Checklist
- [x] I have starred this repository.
- [ ] **New community agents** are under `contributors/<agent-name>/` (not repo root).
- [ ] I ran `ruff check .`.
- [ ] I ran `ruff format .`.
- [ ] I added/updated `README.md` for changed example(s).
- [x] I added `.env.example` if environment variables are required.
- [ ] I added demo image/GIF (if applicable).
- [ ] I added agent profile link (if applicable).
- [ ] I updated `contributors/CHANGELOG.md` for community agent changes, or root `CHANGELOG.md` for other non-doc changes.
- [ ] I added my agent to the **Community Contributors** table in root `README.md` (if new agent).
- [ ] I verified paths/commands used in docs.
- [x] I understand this PR **requires maintainer review** before merge (`review-required` CI).

## Related Issue
Closes #35

## Notes for Reviewers
Checked each folder's Python files directly to get the exact variable names. Folders where everything was hardcoded (like `frontend-integration`) were skipped. The style matches the existing `.env.example` files already in the repo.