### PR TITLE
fix: remove broken README links in gemini quickstart

### DIFF
--- a/gemini-quickstart/README.md
+++ b/gemini-quickstart/README.md
@@ -54,7 +54,7 @@ Fetch and analyze information from URLs
 - Deep thinking mode
 - Summarization and analysis
 
-### 7. [Document Q&A Agent](./07-document-qa-agent/) - Coming Soon
+### 7. Document Q&A Agent - Coming Soon
 Chat with documents using embeddings and RAG
 - Text/URL document upload
 - Semantic search with embeddings
@@ -62,19 +62,19 @@ Chat with documents using embeddings and RAG
 - Retrieval Augmented Generation
 - Per-user document storage
 
-### 8. [Multimodal Agent](./08-multimodal-agent/) - Coming Soon
+### 8. Multimodal Agent - Coming Soon
 Build an agent that handles text, images, and more
 - Image analysis capabilities
 - Multi-format responses
 - Real-world use cases
 
-### 9. [MCP Integration](./09-mcp-integration/) - Coming Soon
+### 9. MCP Integration - Coming Soon
 Add real-world actions to your agent
 - File operations
 - API calls
 - Code execution
 
-### 10. [Multi-Agent Workflow](./10-multi-agent-workflow/) - Coming Soon
+### 10. Multi-Agent Workflow - Coming Soon
 Create agents that work together
 - Agent-to-agent communication
 - Specialized agent roles


### PR DESCRIPTION
## Summary

Removed broken README links in `gemini-quickstart/README.md` that referenced non-existent example directories.

Updated the "Coming Soon" sections to plain text headings so users no longer encounter 404 navigation errors when browsing the repository.

## Type of Change

* [ ] New agent example
* [ ] Bug fix
* [x] Documentation update
* [ ] Refactor / cleanup
* [ ] Other

## Checklist

* [x] I have starred this repository.
* [ ] **New community agents** are under `contributors/<agent-name>/` (not repo root).
* [ ] I ran `ruff check .`.
* [ ] I ran `ruff format .`.
* [x] I added/updated `README.md` for changed example(s).
* [ ] I added `.env.example` if environment variables are required.
* [ ] I added demo image/GIF (if applicable).
* [ ] I added agent profile link (if applicable).
* [ ] I updated `contributors/CHANGELOG.md` for community agent changes, or root `CHANGELOG.md` for other non-doc changes.
* [ ] I added my agent to the **Community Contributors** table in root `README.md` (if new agent).
* [x] I verified paths/commands used in docs.
* [x] I understand this PR **requires maintainer review** before merge (`review-required` CI).

## Related Issue

Closes #119 

## Notes for Reviewers

This PR only updates documentation.

Changes made:

* Removed broken links to:

  * `07-document-qa-agent`
  * `08-multimodal-agent`
  * `09-mcp-integration`
  * `10-multi-agent-workflow`
* Retained the corresponding sections as non-clickable "Coming Soon" entries.
* No code changes were made.
