### PR TITLE
fix: tolerate missing example requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-COPY ${EXAMPLE}/requirements.txt ./requirements.txt
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt
-
 COPY ${EXAMPLE}/ ./
+
+RUN pip install --no-cache-dir --upgrade pip && \
+    if [ -f requirements.txt ]; then \
+        pip install --no-cache-dir -r requirements.txt; \
+    else \
+        echo "No requirements.txt found for ${EXAMPLE}; skipping dependency install."; \
+    fi
 
 RUN if [ -f .env.example ] && [ ! -f .env ]; then cp .env.example .env; fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -87,7 +87,18 @@ else
     echo "[2/4] Virtual environment already exists."
 fi
 
-source .venv/bin/activate
+VENV_ACTIVATE=""
+if [[ -f ".venv/bin/activate" ]]; then
+    VENV_ACTIVATE=".venv/bin/activate"
+elif [[ -f ".venv/Scripts/activate" ]]; then
+    VENV_ACTIVATE=".venv/Scripts/activate"
+else
+    echo "Error: Could not find a virtual environment activation script."
+    echo "Expected .venv/bin/activate or .venv/Scripts/activate."
+    exit 1
+fi
+
+source "$VENV_ACTIVATE"
 
 if [[ -f "requirements.txt" ]]; then
     echo "[3/4] Installing dependencies..."
@@ -118,7 +129,7 @@ echo ""
 echo "=== Setup Complete ==="
 echo ""
 echo "To activate the environment:"
-echo "  cd $EXAMPLE && source .venv/bin/activate"
+echo "  cd $EXAMPLE && source $VENV_ACTIVATE"
 echo ""
 
 if [[ -n "$ENTRY_FILE" ]]; then


### PR DESCRIPTION
## Summary
- make the root Dockerfile skip dependency installation when an example has no top-level `requirements.txt`
- keep `setup.sh` working on Unix and Windows shells by sourcing whichever virtualenv activation script exists

Closes #143

## Validation
- `bash -n setup.sh`
- `git diff --check`
