### PR TITLE
fix: conditional requirements install and cross-platform venv activation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-COPY ${EXAMPLE}/requirements.txt ./requirements.txt
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r requirements.txt
-
 COPY ${EXAMPLE}/ ./
+
+RUN if [ -f requirements.txt ]; then \
+        pip install --no-cache-dir --upgrade pip && \
+        pip install --no-cache-dir -r requirements.txt; \
+    else \
+        echo "No requirements.txt found — skipping dependency install."; \
+    fi
 
 RUN if [ -f .env.example ] && [ ! -f .env ]; then cp .env.example .env; fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -87,7 +87,15 @@ else
     echo "[2/4] Virtual environment already exists."
 fi
 
-source .venv/bin/activate
+if [[ -f ".venv/bin/activate" ]]; then
+    source .venv/bin/activate
+elif [[ -f ".venv/Scripts/activate" ]]; then
+    source .venv/Scripts/activate
+else
+    echo "Error: virtual environment activation script not found in .venv." >&2
+    echo "Try deleting .venv and re-running this script." >&2
+    exit 1
+fi
 
 if [[ -f "requirements.txt" ]]; then
     echo "[3/4] Installing dependencies..."


### PR DESCRIPTION
Closes #143

## Problem
1. `Dockerfile` unconditionally ran `COPY ${EXAMPLE}/requirements.txt` — build crashes for examples without a requirements.txt (`web3`, `mcp-agents`, `gemini-quickstart`).
2. `setup.sh` hardcoded `source .venv/bin/activate` — fails on Windows Git Bash/MSYS2, where venv creates `.venv/Scripts/activate`.

## Changes
### Dockerfile
- Copy `${EXAMPLE}/` first, then install requirements only when the file exists:
```dockerfile
RUN if [ -f requirements.txt ]; then \
        pip install --no-cache-dir --upgrade pip && \
        pip install --no-cache-dir -r requirements.txt; \
    else \
        echo "No requirements.txt found — skipping dependency install."; \
    fi
```

### setup.sh
- Activate the venv from whichever path exists:
```bash
if [[ -f ".venv/bin/activate" ]]; then
    source .venv/bin/activate
elif [[ -f ".venv/Scripts/activate" ]]; then
    source .venv/Scripts/activate
else
    echo "Error: virtual environment activation script not found in .venv." >&2
    echo "Try deleting .venv and re-running this script." >&2
    exit 1
fi
```

## Verification
- `bash -n setup.sh` — syntax OK
- Requirement-present / requirement-absent branches exercised in shell (skip message vs install path)
- Docker daemon not available locally; the RUN logic is plain POSIX if/else validated standalone