### PR TITLE
docs: fix broken star history badge (no token required)

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,13 +285,10 @@ EXAMPLE=fetch-hackathon-quickstarter docker compose up
 ## 📈 Star history
 
 <p align="center">
- <a href="https://www.star-history.com/fetchai/innovation-lab-examples">
-  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/badge?repo=fetchai/innovation-lab-examples&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/badge?repo=fetchai/innovation-lab-examples" />
-   <img alt="Star History Rank for fetchai/innovation-lab-examples" src="https://api.star-history.com/badge?repo=fetchai/innovation-lab-examples" />
-  </picture>
- </a>
+ <a href="https://github.com/fetchai/innovation-lab-examples/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/fetchai/innovation-lab-examples?style=for-the-badge&logo=github&label=Stars&color=1f6feb" /></a>
+ <a href="https://github.com/fetchai/innovation-lab-examples/forks"><img alt="GitHub forks" src="https://img.shields.io/github/forks/fetchai/innovation-lab-examples?style=for-the-badge&logo=github&label=Forks&color=8957e5" /></a>
+ <a href="https://github.com/fetchai/innovation-lab-examples/graphs/contributors"><img alt="Contributors" src="https://img.shields.io/github/contributors/fetchai/innovation-lab-examples?style=for-the-badge&logo=github&label=Contributors&color=2ea043" /></a>
+ <a href="https://github.com/fetchai/innovation-lab-examples/commits/main"><img alt="Last commit" src="https://img.shields.io/github/last-commit/fetchai/innovation-lab-examples?style=for-the-badge&logo=git&label=Last%20commit&color=db6d28" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## What was wrong

The star history section had two blocks. The first one, the star-history **rank badge**, does not work for this repository:

```
$ curl -sL -o /dev/null -w '%{http_code}\n' \
    'https://api.star-history.com/badge?repo=fetchai/innovation-lab-examples'
404
$ curl -sL 'https://api.star-history.com/badge?repo=fetchai/innovation-lab-examples'
not ranked
```

star-history only issues that badge for repositories in its ranking list, so the README was rendering a broken image.

## What changed

Replaced the rank badge with shields.io badges that read live counts from the GitHub API — no token, no account, no login:

| Badge | Source |
|---|---|
| Stars | `img.shields.io/github/stars` |
| Forks | `img.shields.io/github/forks` |
| Contributors | `img.shields.io/github/contributors` |
| Last commit | `img.shields.io/github/last-commit` |

The **star history chart is unchanged** — `api.star-history.com/svg` returns 200 for both the light and dark variants, and needs no token either.

## Verification

Every image URL in the README was checked; all 13 return 200. The 404 above was the only broken one.

Also considered `starchart.cc` as the chart source, but it was returning `400 rate limited` on test, so the existing chart is the more reliable option.