### PR TITLE
fix: use ADK_GCS_BUCKET_NAME in periodic_cleanup

### DIFF
--- a/google-adk/ai-due-diligence-agent/ai_due_diligence_agent/executor.py
+++ b/google-adk/ai-due-diligence-agent/ai_due_diligence_agent/executor.py
@@ -48,7 +48,9 @@ async def periodic_cleanup(ctx: Context) -> None:
 
     try:
         client = storage.Client()
-        bucket = client.bucket("ai-due-diligence-agent")
+        bucket = client.bucket(
+            os.getenv("ADK_GCS_BUCKET_NAME", "ai-due-diligence-agent")
+        )
 
         cutoff = datetime.now(timezone.utc) - timedelta(days=1)
         deleted_count = 0

--- a/google-adk/ai-due-diligence-agent/tests/conftest.py
+++ b/google-adk/ai-due-diligence-agent/tests/conftest.py
@@ -1,0 +1,18 @@
+"""
+Ensure the example root is on sys.path so ai_due_diligence_agent is importable,
+and set placeholder credentials before anything imports the package (several
+dependencies build clients at import time and refuse to import without a key).
+"""
+
+import os
+import sys
+
+os.environ.setdefault("AI_DUE_DILIGENCE_AGENT_SEED", "test-seed")
+os.environ.setdefault("OPENAI_API_KEY", "test-placeholder-key")
+os.environ.setdefault("ASI_ONE_API_KEY", "test-placeholder-key")
+os.environ.setdefault("ASI1_API_KEY", "test-placeholder-key")
+os.environ.setdefault("GOOGLE_API_KEY", "test-placeholder-key")
+
+parent = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if parent not in sys.path:
+    sys.path.insert(0, parent)

--- a/google-adk/ai-due-diligence-agent/tests/test_periodic_cleanup.py
+++ b/google-adk/ai-due-diligence-agent/tests/test_periodic_cleanup.py
@@ -1,0 +1,52 @@
+"""Unit tests for periodic_cleanup — no GCS calls, no network, no uAgents runtime.
+
+Regression test for the bug where periodic_cleanup always targeted a
+hardcoded bucket instead of the bucket configured via ADK_GCS_BUCKET_NAME
+(the same env var the artifact service reads).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ai_due_diligence_agent.executor import periodic_cleanup
+
+
+def _make_ctx():
+    ctx = MagicMock()
+    ctx.logger = MagicMock()
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_periodic_cleanup_uses_configured_bucket(monkeypatch):
+    monkeypatch.setenv("ADK_GCS_BUCKET_NAME", "my-configured-bucket")
+
+    mock_bucket = MagicMock()
+    mock_bucket.list_blobs.return_value = []
+    mock_client = MagicMock()
+    mock_client.bucket.return_value = mock_bucket
+
+    with patch(
+        "ai_due_diligence_agent.executor.storage.Client", return_value=mock_client
+    ):
+        await periodic_cleanup(_make_ctx())
+
+    mock_client.bucket.assert_called_once_with("my-configured-bucket")
+
+
+@pytest.mark.asyncio
+async def test_periodic_cleanup_falls_back_to_default_bucket(monkeypatch):
+    monkeypatch.delenv("ADK_GCS_BUCKET_NAME", raising=False)
+
+    mock_bucket = MagicMock()
+    mock_bucket.list_blobs.return_value = []
+    mock_client = MagicMock()
+    mock_client.bucket.return_value = mock_bucket
+
+    with patch(
+        "ai_due_diligence_agent.executor.storage.Client", return_value=mock_client
+    ):
+        await periodic_cleanup(_make_ctx())
+
+    mock_client.bucket.assert_called_once_with("ai-due-diligence-agent")


### PR DESCRIPTION
## Summary
periodic_cleanup in the AI due-diligence agent's executor.py always
targeted a hardcoded GCS bucket ("ai-due-diligence-agent") instead of
reading ADK_GCS_BUCKET_NAME, the same env var GcsArtifactService uses.
On deployments with a custom bucket configured, the hourly cleanup job
silently cleaned the wrong bucket while logging deleted/retained counts
that described data it never touched. This PR reads the bucket name the
same way the artifact service does, so the write path and the cleanup
path always agree.

## Type of Change
- [ ] New agent example
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other

## Checklist
- [x] I have starred this repository.
- [ ] **New community agents** are under `contributors/<agent-name>/` (not repo root).
- [x] I ran `ruff check .`.
- [x] I ran `ruff format .`.
- [ ] I added/updated `README.md` for changed example(s).
- [ ] I added `.env.example` if environment variables are required.
- [ ] I added demo image/GIF (if applicable).
- [ ] I added agent profile link (if applicable).
- [ ] I updated `contributors/CHANGELOG.md`, if this PR changes a community agent.
- [ ] I added my agent to the **Community Contributors** table in root `README.md` (if new agent).
- [x] I verified paths/commands used in docs.
- [x] I understand this PR **requires maintainer review** before merge (`review-required` CI).

## Related Issue
Fixes #180

## Notes for Reviewers
One-line fix: `client.bucket("ai-due-diligence-agent")` →
`client.bucket(os.getenv("ADK_GCS_BUCKET_NAME", "ai-due-diligence-agent"))`,
matching the existing lookup in the GcsArtifactService setup further
down in the same file. Added tests/test_periodic_cleanup.py with two
cases (configured bucket, default fallback) — verified the new test
fails against the old hardcoded code before the fix, and passes after.